### PR TITLE
Declare SCROLLBAR_WIDTH variable for strict mode

### DIFF
--- a/src/simplebar.js
+++ b/src/simplebar.js
@@ -9,7 +9,7 @@
      * Original function by Jonathan Sharp:
      * http://jdsharp.us/jQuery/minute/calculate-scrollbar-width.php
      */
-    SCROLLBAR_WIDTH = scrollbarWidth();
+    var SCROLLBAR_WIDTH = scrollbarWidth();
 
     function scrollbarWidth () {
         // Append a temporary scrolling element to the DOM, then measure


### PR DESCRIPTION
I was getting the following error after transpiling from ES6 with babel:

`ReferenceError: assignment to undeclared variable SCROLLBAR_WIDTH`