### PR TITLE
Fix module loader detection

### DIFF
--- a/src/simplebar.js
+++ b/src/simplebar.js
@@ -1,14 +1,8 @@
 ;(function (factory) {
-    'use strict';
-    if (typeof define === 'function' && define.amd) {
-        // Register as an anonymous AMD module:
-        define(['jquery'], factory($, window, document, undefined));
-    } else if (typeof exports === 'object') {
-        // Node/CommonJS:
-        factory(require('jquery'), window, document, undefined);
+    if (typeof module === "object" && typeof module.exports === "object") {
+        factory(require('jquery'), window, document);
     } else {
-        // Browser globals:
-        factory(window.jQuery, window, document, undefined);
+        factory(window.jQuery, window, document);
     }
 }(function ( $, window, document, undefined ) {
 


### PR DESCRIPTION
Sorry to bother you again. It turns out that the AMD-style loading was broken. Sorry about that, I should have tested it before submitting the patch.

I have removed it and tidied up the CommonJS environment detection using the recommendation from the npm blog:

http://blog.npmjs.org/post/112712169830/making-your-jquery-plugin-work-better-with-npm