### PR TITLE
Firefox on Linux falsely detects "floating" scrollbars

### DIFF
--- a/src/simplebar.js
+++ b/src/simplebar.js
@@ -20,7 +20,7 @@
     function scrollbarWidth () {
         // Append a temporary scrolling element to the DOM, then measure
         // the difference between its outer and inner elements.
-        var tempEl  = $('<div class="scrollbar-width-tester" style="width:50px;height:50px;overflow-y:scroll;top:-200px;left:-200px;"><div style="height:100px;"></div>'),
+        var tempEl  = $('<div class="scrollbar-width-tester" style="width:150px;height:300px;overflow-y:scroll;top:-9999px;left:-9999px;"><div style="height:100px;"></div>'),
             width   = 0,
             widthMinusScrollbars = 0;
 


### PR DESCRIPTION
Browser doesn't show scrollbars on a small div with overflow visible, mistakenly thinking it has "floating" scrollbars. (https://github.com/Grsmto/simplebar/issues/16)