### PR TITLE
WrapContent issues

### DIFF
--- a/src/simplebar.js
+++ b/src/simplebar.js
@@ -153,7 +153,7 @@ export default class SimpleBar {
     }
 
     initDOM() {
-        if (this.el.querySelectorAll(`.${this.classNames.content}`).length) {
+        if (this._isDomInitialized) {
             return;
         }
         
@@ -188,6 +188,8 @@ export default class SimpleBar {
 
         this.el.insertBefore(this.trackX, this.el.firstChild);
         this.el.insertBefore(this.trackY, this.el.firstChild);
+
+		this.__isDomInitialized = true;
     }
 
     initListeners() {

--- a/src/simplebar.js
+++ b/src/simplebar.js
@@ -54,7 +54,8 @@ export default class SimpleBar {
         return { 
             autoHide: 'data-simplebar-autohide',
             forceEnabled: 'data-simplebar-force-enabled',
-            scrollbarMinSize: 'data-simplebar-scrollbar-min-size'
+            scrollbarMinSize: 'data-simplebar-scrollbar-min-size',
+            wrapContent: 'data-simplebar-wrap-content'
         }
     }
 
@@ -188,8 +189,8 @@ export default class SimpleBar {
 
         this.el.insertBefore(this.trackX, this.el.firstChild);
         this.el.insertBefore(this.trackY, this.el.firstChild);
-
-		this.__isDomInitialized = true;
+        
+        this.__isDomInitialized = true;
     }
 
     initListeners() {


### PR DESCRIPTION
Allow wrapContent to be set via data attribute. Fix issue where, when wrapContent = false, scroll bars don't get added and error is thrown later.