### PR TITLE
Recalculate when child node has been mutated

### DIFF
--- a/src/simplebar.js
+++ b/src/simplebar.js
@@ -206,7 +206,7 @@ export default class SimpleBar {
             // create an observer instance
             this.observer = new MutationObserver(mutations => {
                 mutations.forEach(mutation => {
-                    if (mutation.target === this.el || mutation.addedNodes.length) {
+                    if (this.isChildNode(mutation.target) || mutation.addedNodes.length) {
                         this.recalculate();
                     }
                 });
@@ -446,6 +446,16 @@ export default class SimpleBar {
     unMount() {
         this.removeListeners();
         this.el.SimpleBar = null;
+    }
+
+    /**
+     * Recursively walks up the parent nodes looking for this.el
+     */
+    isChildNode(el) {
+        if (el === null) return false;
+        if (el === this.el) return true
+        
+        return this.isChildNode(el.parentNode);
     }
 }
 

--- a/src/simplebar.js
+++ b/src/simplebar.js
@@ -453,7 +453,7 @@ export default class SimpleBar {
      */
     isChildNode(el) {
         if (el === null) return false;
-        if (el === this.el) return true
+        if (el === this.el) return true;
         
         return this.isChildNode(el.parentNode);
     }


### PR DESCRIPTION
Changed the condition where recalculate was being called on the MutationObserver. It will recalculate when any child of "this.el" has been mutated. I noticed this issue when I had an accordion in the content area. The children of the content area were mutating, but not the element itself. I didn't see any visual performance degradation with this change, but it could be argued this adds some unnecessary overhead. It did fix my issue though.

I'd be happy to create a plunkr if you would like an example.