### PR TITLE
Add jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Then don't forget to import both css and js in your project.
 ```
 <link rel="stylesheet" href="https://unpkg.com/simplebar@latest/dist/simplebar.css" />
 <script src="https://unpkg.com/simplebar@latest/dist/simplebar.js"></script>
+<!-- or -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simplebar@latest/dist/simplebar.css">
+<script src="https://cdn.jsdelivr.net/npm/simplebar@latest/dist/simplebar.js"></script>
 ```
 note: you can replace `@latest` to the latest version (ex `@2.4.3`), if you want to lock to a specific version
 


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/simplebar) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability.