### PR TITLE
Fix 'visible' classname bug when using custom classnames

### DIFF
--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -571,12 +571,12 @@ export default class SimpleBar {
     this.axis.y.track.rect = this.axis.y.track.el.getBoundingClientRect();
 
     if (!this.isWithinBounds(this.axis.y.track.rect)) {
-      this.axis.y.scrollbar.el.classList.remove('visible');
+      this.axis.y.scrollbar.el.classList.remove(this.classNames.visible);
       this.axis.y.isVisible = false;
     }
 
     if (!this.isWithinBounds(this.axis.x.track.rect)) {
-      this.axis.x.scrollbar.el.classList.remove('visible');
+      this.axis.x.scrollbar.el.classList.remove(this.classNames.visible);
       this.axis.x.isVisible = false;
     }
   }


### PR DESCRIPTION
See issue #238. Officially my first PR to GitHub, hopefully guide wasn't lying.