### PR TITLE
recalculate when nodes are removed as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Set `data-simplebar` on the element you want your custom scrollbar. You're done.
 SimpleBar is **not intended to be used on the `body` element!** I don't recommend wrapping your entire web page inside a custom scroll as it will often badly affect the user experience (slower scroll performance compared to the native body scroll, no native scroll behaviours like click on track, etc.). Do it at your own risk! SimpleBar is meant to improve the experience of **internal web page scrolling**; such as a chat box or a small scrolling area. **Please read the [caveats](#5-caveats) section first to be aware of the limitations!**
 
 ### Troubleshooting
-If you are experiencing issues when setting up SimpleBar, it is most likely because your styles are clashing with SimpleBar ones. Make sure the element you are setting SimpleBar on does not override any SimpleBar css properties! We recommend to not style that element at all and use an inner element instead.
+If you are experiencing issues when setting up SimpleBar, it is most likely because your styles are clashing with SimpleBar ones. Make sure the element you are setting SimpleBar on does not override any SimpleBar css properties! **We recommend to not style that element at all and use an inner element instead.**
 
 ### Sponsors
 Thanks to BrowserStack for sponsoring open source projects and letting us test SimpleBar for free.
@@ -144,6 +144,16 @@ classNames: {
   track: 'simplebar-track'
 }
 ```
+
+#### forceVisible
+You can force the track to be visible (same behaviour as `overflow: scroll`) using the `forceVisible` option:
+```
+forceVisible: true|'x'|'y' (default to `false`)
+```
+By default, SimpleBar behave like `overflow: auto`.
+
+### Apply scroll vertically only
+Simply define in css `overflow-x: hidden` on your element.
 
 ### Notifying the plugin of content changes
 #### Note: you shouldn't need to use these functions as SimpleBar takes care of that automatically. This is for advanced usage only.

--- a/packages/simplebar-react/package.json
+++ b/packages/simplebar-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplebar-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React component for SimpleBar",
   "files": [
     "dist"
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.1",
-    "simplebar": "^3.1.0"
+    "simplebar": "^3.1.1"
   },
   "peerDependencies": {
     "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0",

--- a/packages/simplebar-vue/package.json
+++ b/packages/simplebar-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplebar-vue",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Vue component for SimpleBar",
   "files": [
     "dist"
@@ -18,7 +18,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "simplebar": "^3.1.0",
+    "simplebar": "^3.1.1",
     "vue": "^2.5.17"
   },
   "peerDependencies": {

--- a/packages/simplebar/package.json
+++ b/packages/simplebar/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.0",
+  "version": "3.1.1",
   "name": "simplebar",
   "title": "SimpleBar.js",
   "description": "Scrollbars, simpler.",

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -379,7 +379,8 @@ export default class SimpleBar {
           if (
             mutation.target === this.el ||
             !this.isChildNode(mutation.target) ||
-            mutation.addedNodes.length
+            mutation.addedNodes.length ||
+            mutation.removedNodes.length
           ) {
             this.recalculate();
           }


### PR DESCRIPTION
quick fix to recalculate simplebar when nodes are removed as well as added. 
useful when you have accordion component inside fixed container with simplebar.  