### PR TITLE
simplebar-react: Now supports passing props to scrollable node.

### DIFF
--- a/packages/simplebar-react/__snapshots__/index.test.js.snap
+++ b/packages/simplebar-react/__snapshots__/index.test.js.snap
@@ -63,6 +63,71 @@ exports[`renders with options 1`] = `
 </div>
 `;
 
+
+exports[`renders with scrollableNodeProps 1`] = `
+<div
+  data-simplebar={true}
+  data-simplebar-auto-hide="false"
+>
+  <div
+    className="simplebar-wrapper"
+  >
+    <div
+      className="simplebar-height-auto-observer-wrapper"
+    >
+      <div
+        className="simplebar-height-auto-observer"
+      />
+    </div>
+    <div
+      className="simplebar-mask"
+    >
+      <div
+        className="simplebar-offset"
+      >
+        <div
+          className="simplebar-content test"
+          data-test="test"
+        >
+          <p>
+            Some content
+          </p>
+          <p>
+            Some content
+          </p>
+          <p>
+            Some content
+          </p>
+          <p>
+            Some content
+          </p>
+          <p>
+            Some content
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      className="simplebar-placeholder"
+    />
+  </div>
+  <div
+    className="simplebar-track simplebar-horizontal"
+  >
+    <div
+      className="simplebar-scrollbar"
+    />
+  </div>
+  <div
+    className="simplebar-track simplebar-vertical"
+  >
+    <div
+      className="simplebar-scrollbar"
+    />
+  </div>
+</div>
+`;
+
 exports[`renders without crashing 1`] = `
 <div
   data-simplebar={true}

--- a/packages/simplebar-react/index.js
+++ b/packages/simplebar-react/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import 'simplebar';
 
-export default function SimpleBar({ children, ...options }) {
+export default function SimpleBar({ children, scrollableNodeProps, ...options }) {
   return <div data-simplebar {...options}>
       <div className="simplebar-wrapper">
         <div className="simplebar-height-auto-observer-wrapper">
@@ -10,7 +10,7 @@ export default function SimpleBar({ children, ...options }) {
         </div>
         <div className="simplebar-mask">
           <div className="simplebar-offset">
-            <div className="simplebar-content">{children}</div>
+            <div {...scrollableNodeProps} className={`simplebar-content${scrollableNodeProps && scrollableNodeProps.className ? ` ${scrollableNodeProps.className}` : ''}`}>{children}</div>
           </div>
         </div>
         <div className="simplebar-placeholder" />

--- a/packages/simplebar-react/index.test.js
+++ b/packages/simplebar-react/index.test.js
@@ -26,3 +26,15 @@ test('renders with options', () => {
   let tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('renders with scrollableNodeProps', () => {
+  const component = renderer.create(
+    <SimpleBar scrollableNodeProps={{ className: 'test', 'data-test': "test" }} data-simplebar-auto-hide="false">
+      {[...Array(5)].map((x, i) =>
+        <p key={i}>Some content</p>
+      )}
+    </SimpleBar>
+  );
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});


### PR DESCRIPTION
This allow usage with libraries that control scrolling like react-beautiful-dnd, which requires passing ref to scrollable container.