### PR TITLE
fix: ResizeObserver loop limit exceeded #286

### DIFF
--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -407,7 +407,11 @@ export default class SimpleBar {
       });
     }
 
-    this.resizeObserver = new ResizeObserver(this.recalculate);
+    this.resizeObserver = new ResizeObserver(() => {
+      window.requestAnimationFrame(() => {
+        this.recalculate();
+      });
+    });
     this.resizeObserver.observe(this.el);
     this.resizeObserver.observe(this.resizeWrapperEl);
   }


### PR DESCRIPTION
Hi,
this little fix is related to #286.
Sometimes it is possible to get `resizeObserver loop limit exceeded` error.

Here you can find more information about the problem and the solution: https://github.com/hshoff/vx/pull/335
