### PR TITLE
isOverflowing isn't set correctly when resizing the horizontal/vertical scrollbar.

### DIFF
--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -449,8 +449,8 @@ export default class SimpleBar {
         : this.contentEl.scrollHeight - this.minScrollbarWidth) >
       Math.ceil(this.axis.y.track.rect.height);
     */
-    this.axis.x.isOverflowing = this.contentEl > this.contentEl.clientHeight;
-    this.axis.y.isOverflowing = this.contentEl.scrollHeight > this.contentEl.clientHeight; // Set isOverflowing to false if user explicitely set hidden overflow
+   this.axis.x.isOverflowing = this.contentEl.scrollWidth > this.contentEl.clientWidth;
+   this.axis.y.isOverflowing = this.contentEl.scrollHeight > this.contentEl.clientHeight; // Set isOverflowing to false if user explicitely set hidden overflow
     // Set isOverflowing to false if user explicitely set hidden overflow
     this.axis.x.isOverflowing =
       this.elStyles.overflowX === 'hidden' ? false : this.axis.x.isOverflowing;

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -438,7 +438,7 @@ export default class SimpleBar {
     this.axis.y.track.rect = this.axis.y.track.el.getBoundingClientRect();
 
     // Set isOverflowing to false if scrollbar is not necessary (content is shorter than offset)
-    this.axis.x.isOverflowing =
+    /*this.axis.x.isOverflowing =
       (this.scrollbarWidth
         ? this.contentEl.scrollWidth
         : this.contentEl.scrollWidth - this.minScrollbarWidth) >
@@ -448,7 +448,9 @@ export default class SimpleBar {
         ? this.contentEl.scrollHeight
         : this.contentEl.scrollHeight - this.minScrollbarWidth) >
       Math.ceil(this.axis.y.track.rect.height);
-
+    */
+    this.axis.x.isOverflowing = this.contentEl > this.contentEl.clientHeight;
+    this.axis.y.isOverflowing = this.contentEl.scrollHeight > this.contentEl.clientHeight; // Set isOverflowing to false if user explicitely set hidden overflow
     // Set isOverflowing to false if user explicitely set hidden overflow
     this.axis.x.isOverflowing =
       this.elStyles.overflowX === 'hidden' ? false : this.axis.x.isOverflowing;


### PR DESCRIPTION
Aight, figured out how to create fork.

Found a bug where resizing the vertical/horizontal bar by modifying it's width/height to less than 100% would break the isOverflowing check and cause the scrollbar to display even if the content does not overflow. Fixed it by checking the content element's scrollwidth/height with its respective clientWidth/Height in the recalculate function.