### PR TITLE
Add methods to vue component

### DIFF
--- a/packages/simplebar-vue/__snapshots__/index.test.js.snap
+++ b/packages/simplebar-vue/__snapshots__/index.test.js.snap
@@ -1,49 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`simplebar renders with options 1`] = `
-<div data-simplebar="" data-simplebar-auto-hide="false">
+<div data-simplebar-auto-hide="false" data-simplebar="init">
   <div class="simplebar-wrapper">
     <div class="simplebar-height-auto-observer-wrapper">
       <div class="simplebar-height-auto-observer"></div>
     </div>
     <div class="simplebar-mask">
-      <div class="simplebar-offset">
-        <div class="simplebar-content-wrapper">
+      <div class="simplebar-offset" style="right: 0px; bottom: 0px;">
+        <div class="simplebar-content-wrapper" style="height: auto; padding-right: 0px; padding-bottom: 0px; overflow-x: hidden; overflow-y: hidden;">
           <div class="simplebar-content"></div>
         </div>
       </div>
     </div>
-    <div class="simplebar-placeholder"></div>
+    <div class="simplebar-placeholder" style="width: 0px; height: 0px;"></div>
   </div>
-  <div class="simplebar-track simplebar-horizontal">
-    <div class="simplebar-scrollbar"></div>
+  <div class="simplebar-track simplebar-horizontal" style="visibility: hidden;">
+    <div class="simplebar-scrollbar simplebar-visible" style="transform: translate3d(0px, 0, 0); display: none;"></div>
   </div>
-  <div class="simplebar-track simplebar-vertical">
-    <div class="simplebar-scrollbar"></div>
+  <div class="simplebar-track simplebar-vertical" style="visibility: hidden;">
+    <div class="simplebar-scrollbar simplebar-visible" style="transform: translate3d(0, 0px, 0); display: none;"></div>
   </div>
 </div>
 `;
 
 exports[`simplebar renders without crashing 1`] = `
-<div data-simplebar="">
+<div data-simplebar="init">
   <div class="simplebar-wrapper">
     <div class="simplebar-height-auto-observer-wrapper">
       <div class="simplebar-height-auto-observer"></div>
     </div>
     <div class="simplebar-mask">
-      <div class="simplebar-offset">
-        <div class="simplebar-content-wrapper">
+      <div class="simplebar-offset" style="right: 0px; bottom: 0px;">
+        <div class="simplebar-content-wrapper" style="height: auto; padding-right: 0px; padding-bottom: 0px; overflow-x: hidden; overflow-y: hidden;">
           <div class="simplebar-content"></div>
         </div>
       </div>
     </div>
-    <div class="simplebar-placeholder"></div>
+    <div class="simplebar-placeholder" style="width: 0px; height: 0px;"></div>
   </div>
-  <div class="simplebar-track simplebar-horizontal">
-    <div class="simplebar-scrollbar"></div>
+  <div class="simplebar-track simplebar-horizontal" style="visibility: hidden;">
+    <div class="simplebar-scrollbar" style="transform: translate3d(0px, 0, 0); display: none;"></div>
   </div>
-  <div class="simplebar-track simplebar-vertical">
-    <div class="simplebar-scrollbar"></div>
+  <div class="simplebar-track simplebar-vertical" style="visibility: hidden;">
+    <div class="simplebar-scrollbar" style="transform: translate3d(0, 0px, 0); display: none;"></div>
   </div>
 </div>
 `;

--- a/packages/simplebar-vue/__snapshots__/index.test.js.snap
+++ b/packages/simplebar-vue/__snapshots__/index.test.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`simplebar renders with default slot 1`] = `
+<div data-simplebar="init">
+  <div class="simplebar-wrapper">
+    <div class="simplebar-height-auto-observer-wrapper">
+      <div class="simplebar-height-auto-observer"></div>
+    </div>
+    <div class="simplebar-mask">
+      <div class="simplebar-offset" style="right: 0px; bottom: 0px;">
+        <div class="simplebar-content-wrapper" style="height: auto; padding-right: 0px; padding-bottom: 0px; overflow-x: hidden; overflow-y: hidden;">
+          <div class="simplebar-content">
+            <div class="inner-content"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="simplebar-placeholder" style="width: 0px; height: 0px;"></div>
+  </div>
+  <div class="simplebar-track simplebar-horizontal" style="visibility: hidden;">
+    <div class="simplebar-scrollbar" style="transform: translate3d(0px, 0, 0); display: none;"></div>
+  </div>
+  <div class="simplebar-track simplebar-vertical" style="visibility: hidden;">
+    <div class="simplebar-scrollbar" style="transform: translate3d(0, 0px, 0); display: none;"></div>
+  </div>
+</div>
+`;
+
 exports[`simplebar renders with options 1`] = `
 <div data-simplebar-auto-hide="false" data-simplebar="init">
   <div class="simplebar-wrapper">

--- a/packages/simplebar-vue/index.test.js
+++ b/packages/simplebar-vue/index.test.js
@@ -29,30 +29,20 @@ describe('simplebar', () => {
     expect(wrapper.vm.SimpleBar).toBeDefined();
   });
 
-  it('can access getScrollElement method', () => {
+  it('can access scrollElement property', () => {
     const wrapper = shallowMount(simplebar);
-    const scrollElement = wrapper.vm.getScrollElement();
+    const scrollElement = wrapper.vm.scrollElement;
 
     expect(scrollElement).toEqual(
       wrapper.find('.simplebar-content-wrapper').element
     );
   });
 
-  it('can access getContentElement method', () => {
+  it('can access contentElement property', () => {
     const wrapper = shallowMount(simplebar);
-    const scrollElement = wrapper.vm.getContentElement();
+    const scrollElement = wrapper.vm.contentElement;
 
     expect(scrollElement).toEqual(wrapper.find('.simplebar-content').element);
-  });
-
-  it('can access recalculate method', () => {
-    const wrapper = shallowMount(simplebar);
-
-    const recalculateMock = jest.fn();
-    wrapper.vm.SimpleBar.recalculate = recalculateMock;
-    wrapper.vm.recalculate();
-
-    expect(recalculateMock).toBeCalled();
   });
 
   it('works with options as attribute', () => {

--- a/packages/simplebar-vue/index.test.js
+++ b/packages/simplebar-vue/index.test.js
@@ -22,4 +22,54 @@ describe('simplebar', () => {
     });
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('can access SimpleBar instance', () => {
+    const wrapper = shallowMount(simplebar);
+
+    expect(wrapper.vm.SimpleBar).toBeDefined();
+  });
+
+  it('can access getScrollElement method', () => {
+    const wrapper = shallowMount(simplebar);
+    const scrollElement = wrapper.vm.getScrollElement();
+
+    expect(scrollElement).toEqual(
+      wrapper.find('.simplebar-content-wrapper').element
+    );
+  });
+
+  it('can access getContentElement method', () => {
+    const wrapper = shallowMount(simplebar);
+    const scrollElement = wrapper.vm.getContentElement();
+
+    expect(scrollElement).toEqual(wrapper.find('.simplebar-content').element);
+  });
+
+  it('can access recalculate method', () => {
+    const wrapper = shallowMount(simplebar);
+
+    const recalculateMock = jest.fn();
+    wrapper.vm.SimpleBar.recalculate = recalculateMock;
+    wrapper.vm.recalculate();
+
+    expect(recalculateMock).toBeCalled();
+  });
+
+  it('works with options as attribute', () => {
+    const wrapper = shallowMount(simplebar, {
+      propsData: { 'data-simplebar-auto-hide': 'false' }
+    });
+    expect(wrapper.vm.SimpleBar.options.autoHide).toEqual(false);
+  });
+
+  it('works with options as prop', () => {
+    const wrapper = shallowMount(simplebar, {
+      propsData: {
+        options: {
+          autoHide: false
+        }
+      }
+    });
+    expect(wrapper.vm.SimpleBar.options.autoHide).toEqual(false);
+  });
 });

--- a/packages/simplebar-vue/index.test.js
+++ b/packages/simplebar-vue/index.test.js
@@ -61,15 +61,4 @@ describe('simplebar', () => {
     });
     expect(wrapper.vm.SimpleBar.options.autoHide).toEqual(false);
   });
-
-  it('works with options as prop', () => {
-    const wrapper = shallowMount(simplebar, {
-      propsData: {
-        options: {
-          autoHide: false
-        }
-      }
-    });
-    expect(wrapper.vm.SimpleBar.options.autoHide).toEqual(false);
-  });
 });

--- a/packages/simplebar-vue/index.test.js
+++ b/packages/simplebar-vue/index.test.js
@@ -13,4 +13,13 @@ describe('simplebar', () => {
     });
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('renders with default slot', () => {
+    const wrapper = shallowMount(simplebar, {
+      slots: {
+        default: '<div class="inner-content" />'
+      }
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/packages/simplebar-vue/index.vue
+++ b/packages/simplebar-vue/index.vue
@@ -31,29 +31,19 @@ import SimpleBar from 'simplebar';
 
 export default {
   name: 'simplebar-vue',
-  data () {
-    return {
-      instance: null
-    }
-  },
   mounted () {
     const options = SimpleBar.getElOptions(this.$refs.element)
-    this.instance = new SimpleBar(this.$refs.element, options)
+    this.SimpleBar = new SimpleBar(this.$refs.element, options)
   },
   methods: {
     getScrollElement () {
-      return this.instance.getScrollElement()
+      return this.SimpleBar.getScrollElement()
     },
     getContentElement () {
-      return this.instance.getContentElement()
+      return this.SimpleBar.getContentElement()
     },
     recalculate () {
-      return this.instance.recalculate()
-    }
-  },
-  computed: {
-    SimpleBar () {
-      return this.instance
+      return this.SimpleBar.recalculate()
     }
   }
 }

--- a/packages/simplebar-vue/index.vue
+++ b/packages/simplebar-vue/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    data-simplebar
+    ref="element"
   >
     <div class="simplebar-wrapper">
         <div class="simplebar-height-auto-observer-wrapper">
@@ -27,8 +27,24 @@
 </template>
 
 <script>
-import 'simplebar';
+import SimpleBar from 'simplebar';
+
 export default {
-  name: 'simplebar-vue'
+  name: 'simplebar-vue',
+  props: {
+    options: {
+      type: Object,
+      required: false
+    }
+  },
+  data () {
+    return {
+      instance: null
+    }
+  },
+  mounted () {
+    const options = this.options || SimpleBar.getElOptions(this.$refs.element)
+    this.instance = new SimpleBar(this.$refs.element, options)
+  }
 }
 </script>

--- a/packages/simplebar-vue/index.vue
+++ b/packages/simplebar-vue/index.vue
@@ -45,6 +45,22 @@ export default {
   mounted () {
     const options = this.options || SimpleBar.getElOptions(this.$refs.element)
     this.instance = new SimpleBar(this.$refs.element, options)
+  },
+  methods: {
+    getScrollElement () {
+      return this.instance.getScrollElement()
+    },
+    getContentElement () {
+      return this.instance.getContentElement()
+    },
+    recalculate () {
+      return this.instance.recalculate()
+    }
+  },
+  computed: {
+    SimpleBar () {
+      return this.instance
+    }
   }
 }
 </script>

--- a/packages/simplebar-vue/index.vue
+++ b/packages/simplebar-vue/index.vue
@@ -31,19 +31,13 @@ import SimpleBar from 'simplebar';
 
 export default {
   name: 'simplebar-vue',
-  props: {
-    options: {
-      type: Object,
-      required: false
-    }
-  },
   data () {
     return {
       instance: null
     }
   },
   mounted () {
-    const options = this.options || SimpleBar.getElOptions(this.$refs.element)
+    const options = SimpleBar.getElOptions(this.$refs.element)
     this.instance = new SimpleBar(this.$refs.element, options)
   },
   methods: {

--- a/packages/simplebar-vue/index.vue
+++ b/packages/simplebar-vue/index.vue
@@ -8,8 +8,8 @@
         </div>
         <div class="simplebar-mask">
           <div class="simplebar-offset">
-            <div class="simplebar-content-wrapper">
-              <div class="simplebar-content">
+            <div class="simplebar-content-wrapper" ref="scrollElement">
+              <div class="simplebar-content" ref="contentElement">
                 <slot></slot>
               </div>
             </div>
@@ -32,18 +32,15 @@ import SimpleBar from 'simplebar';
 export default {
   name: 'simplebar-vue',
   mounted () {
-    const options = SimpleBar.getElOptions(this.$refs.element)
-    this.SimpleBar = new SimpleBar(this.$refs.element, options)
+    const options = SimpleBar.getElOptions(this.$refs.element);
+    this.SimpleBar = new SimpleBar(this.$refs.element, options);
   },
-  methods: {
-    getScrollElement () {
-      return this.SimpleBar.getScrollElement()
+  computed: {
+    scrollElement () {
+      return this.$refs.scrollElement;
     },
-    getContentElement () {
-      return this.SimpleBar.getContentElement()
-    },
-    recalculate () {
-      return this.SimpleBar.recalculate()
+    contentElement () {
+      return this.$refs.contentElement;
     }
   }
 }


### PR DESCRIPTION
This pull request makes so `SimpleBar` is initialized when `simplebar-vue` component is mounted, adds ability to access `SimpleBar` instance and call `getScrollElement`, `getContentElement` and `recalculate` methods directly on `simplebar-vue` component instance.
This will simplify https://github.com/Grsmto/simplebar/issues/331#issuecomment-501284326:
- it will be possible to use `this.$refs.container.getScrollElement()` instead of `this.$refs.container.$el.SimpleBar.getScrollElement()`
- `SimpleBar` will be property initialized in `mounted` hook