### PR TITLE
Fixes scrollableNodeProps

### DIFF
--- a/packages/simplebar-react/__snapshots__/index.test.js.snap
+++ b/packages/simplebar-react/__snapshots__/index.test.js.snap
@@ -89,11 +89,11 @@ exports[`renders with scrollableNodeProps 1`] = `
         className="simplebar-offset"
       >
         <div
-          className="simplebar-content-wrapper"
+          className="simplebar-content-wrapper test"
+          data-test="test"
         >
           <div
-            className="simplebar-content test"
-            data-test="test"
+            className="simplebar-content"
           >
             <p>
               Some content

--- a/packages/simplebar-react/index.js
+++ b/packages/simplebar-react/index.js
@@ -15,14 +15,14 @@ export default function SimpleBar({
         </div>
         <div className="simplebar-mask">
           <div className="simplebar-offset">
-            <div className="simplebar-content-wrapper">
+            <div {...scrollableNodeProps}
+                 className={`simplebar-content-wrapper${
+                   scrollableNodeProps && scrollableNodeProps.className
+                     ? ` ${scrollableNodeProps.className}`
+                     : ''
+                   }`}>
               <div
-                {...scrollableNodeProps}
-                className={`simplebar-content${
-                  scrollableNodeProps && scrollableNodeProps.className
-                    ? ` ${scrollableNodeProps.className}`
-                    : ''
-                }`}
+                className="simplebar-content"
               >
                 {children}
               </div>


### PR DESCRIPTION
Since simplebar-content-wrapper now handles scrolling, scrollableNodeProps should be applied to simplebar-content-wrapper instead of simplebar-content