### PR TITLE
Fix track elements selector

### DIFF
--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -919,9 +919,7 @@ export default class SimpleBar {
    * Find element children matches query
    */
   findChild(el, query) {
-    const matches = el.matches || el.webkitMatchesSelector || el.mozMatchesSelector || el.msMatchesSelector;
-	
-    return Array.prototype.filter.call(el.children, child => matches.call(child, query))[0];
+    return Array.prototype.filter.call(el.children, child => child.matches(query))[0];
   }
 }
 

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -297,10 +297,10 @@ export default class SimpleBar {
       this.heightAutoObserverEl = this.el.querySelector(
         `.${this.classNames.heightAutoObserverEl}`
       );
-      this.axis.x.track.el = this.el.querySelector(
+      this.axis.x.track.el = this.findChild(this.el,
         `.${this.classNames.track}.${this.classNames.horizontal}`
       );
-      this.axis.y.track.el = this.el.querySelector(
+      this.axis.y.track.el = this.findChild(this.el,
         `.${this.classNames.track}.${this.classNames.vertical}`
       );
     } else {
@@ -913,6 +913,15 @@ export default class SimpleBar {
       this.mouseY >= bbox.top &&
       this.mouseY <= bbox.top + bbox.height
     );
+  }
+
+  /**
+   * Find element children matches query
+   */
+  findChild(el, query) {
+    const matches = el.matches || el.webkitMatchesSelector || el.mozMatchesSelector || el.msMatchesSelector;
+	
+    return Array.prototype.filter.call(el.children, child => matches.call(child, query))[0];
   }
 }
 


### PR DESCRIPTION
`this.el.querySelector` returns wrong element if there is nested `.simplebar-track` exist. This cause issues with nested simplebars in some cases (e.g. simplebar-react which creates full dom tree including tracks). Searching for track element inside immediate children solves this issue.