### PR TITLE
fix: defining of isOverflowing may be not presize.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 yarn-error.log
 .next
+.idea

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -429,9 +429,11 @@ export default class SimpleBar {
 
     // Set isOverflowing to false if scrollbar is not necessary (content is shorter than offset)
     this.axis.x.isOverflowing =
-      this.contentWrapperEl.scrollWidth > this.contentWrapperEl.offsetWidth;
+      this.contentWrapperEl.scrollWidth > this.contentWrapperEl.offsetWidth -
+      (this.scrollbarWidth || this.minScrollbarWidth);
     this.axis.y.isOverflowing =
-      this.contentWrapperEl.scrollHeight > this.contentWrapperEl.offsetHeight;
+      this.contentWrapperEl.scrollHeight > this.contentWrapperEl.offsetWidth -
+      (this.scrollbarWidth || this.minScrollbarWidth);
 
     // Set isOverflowing to false if user explicitely set hidden overflow
     this.axis.x.isOverflowing =

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -428,12 +428,18 @@ export default class SimpleBar {
     this.placeholderEl.style.height = `${this.contentEl.scrollHeight}px`;
 
     // Set isOverflowing to false if scrollbar is not necessary (content is shorter than offset)
+    let offsetForXScrollbar = this.axis.x.isOverflowing
+      ? this.scrollbarWidth || this.minScrollbarWidth
+      : 0;
+    let offsetForYScrollbar = this.axis.y.isOverflowing
+      ? this.scrollbarWidth || this.minScrollbarWidth
+      : 0;
     this.axis.x.isOverflowing =
-      this.contentWrapperEl.scrollWidth > this.contentWrapperEl.offsetWidth -
-      (this.scrollbarWidth || this.minScrollbarWidth);
+      this.contentWrapperEl.scrollWidth >
+      this.contentWrapperEl.offsetWidth - offsetForYScrollbar;
     this.axis.y.isOverflowing =
-      this.contentWrapperEl.scrollHeight > this.contentWrapperEl.offsetWidth -
-      (this.scrollbarWidth || this.minScrollbarWidth);
+      this.contentWrapperEl.scrollHeight >
+      this.contentWrapperEl.offsetHeight - offsetForXScrollbar;
 
     // Set isOverflowing to false if user explicitely set hidden overflow
     this.axis.x.isOverflowing =

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -429,9 +429,9 @@ export default class SimpleBar {
 
     // Set isOverflowing to false if scrollbar is not necessary (content is shorter than offset)
     this.axis.x.isOverflowing =
-      this.contentWrapperEl.scrollWidth > this.contentWrapperEl.clientWidth;
+      this.contentWrapperEl.scrollWidth > this.contentWrapperEl.offsetWidth;
     this.axis.y.isOverflowing =
-      this.contentWrapperEl.scrollHeight > this.contentWrapperEl.clientHeight;
+      this.contentWrapperEl.scrollHeight > this.contentWrapperEl.offsetHeight;
 
     // Set isOverflowing to false if user explicitely set hidden overflow
     this.axis.x.isOverflowing =

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -429,9 +429,9 @@ export default class SimpleBar {
 
     // Set isOverflowing to false if scrollbar is not necessary (content is shorter than offset)
     this.axis.x.isOverflowing =
-      this.contentWrapperEl.scrollWidth > this.contentWrapperEl.offsetWidth;
+      this.contentWrapperEl.scrollWidth > this.contentWrapperEl.clientWidth;
     this.axis.y.isOverflowing =
-      this.contentWrapperEl.scrollHeight > this.contentWrapperEl.offsetHeight;
+      this.contentWrapperEl.scrollHeight > this.contentWrapperEl.clientHeight;
 
     // Set isOverflowing to false if user explicitely set hidden overflow
     this.axis.x.isOverflowing =


### PR DESCRIPTION
Hi @Grsmto , thanks for your awesome scroller!
I had a issue with some deep nesting offsets. Particularly I had situation in the Storybook (https://github.com/storybookjs/storybook) when vertical scrollbar must be visible, but it wasn’t.
I propose to changed offsetWidth and offsetHeight to clientWidth and clientHeight for more accurate defining of isOverflowing.

You can see the difference in the log:
![Screenshot from 2019-08-23 19-32-19](https://user-images.githubusercontent.com/24456439/63609472-dbf29d80-c5df-11e9-85d6-a35901a54bc4.jpg)
