### PR TITLE
fix: set pointer-events: none when dragging to avoid interactivity on…

### DIFF
--- a/packages/simplebar/demo/Demo.js
+++ b/packages/simplebar/demo/Demo.js
@@ -52,7 +52,9 @@ class Demo extends React.Component {
               <h3 className="sticky">Sticky header</h3>
               {[...Array(50)].map((x, i) => (
                 <p key={i} className="odd">
-                  Some content
+                  Some content Some content Some content Some content Some
+                  content Some content
+                  <button>click</button>
                 </p>
               ))}
             </div>

--- a/packages/simplebar/demo/browser/css/demo.css
+++ b/packages/simplebar/demo/browser/css/demo.css
@@ -20,7 +20,7 @@ body {
 }
 
 section:after {
-  content: "";
+  content: '';
   display: table;
   clear: both;
 }
@@ -62,40 +62,45 @@ p {
   -webkit-border-radius: 5px;
   -o-border-radius: 5px;
   border-radius: 5px;
-  }
-  .btn:hover {
-    background: #666;
-    color: #fff;
-    }
-  .btn:visited {
-    color: #fff;
-    }
+}
+.btn:hover {
+  background: #666;
+  color: #fff;
+}
+.btn:visited {
+  color: #fff;
+}
 
 /* Scrollable elements
 *****************************************************************/
-.demo1, .demo3 {
+.demo1,
+.demo3 {
   margin: 10px 0;
   width: 100%;
   height: 300px;
 }
-  .demo1 p {
-    margin: 0;
-    padding: 10px;
-    min-width: 230px;
-    }
-    .demo1 p.odd:hover {
-      background: #666;
-      height: 100px;
-    }
-    .demo1 p.odd {
-      background: #f0f0f0;
-      }
-  .demo1.width {
-    width: 230px;
-  }
-  .demo1.height {
-    height: 200px;
-  }
+.demo1 p {
+  margin: 0;
+  padding: 10px;
+  min-width: 230px;
+}
+.demo1 p.odd:hover {
+  background: #666;
+  height: 100px;
+}
+.demo1 p.odd {
+  background: #f0f0f0;
+}
+.demo1.width {
+  width: 230px;
+}
+.demo1.height {
+  height: 200px;
+}
+#demo1 p {
+  text-align: right;
+  padding: 0;
+}
 .demo1-internal {
   width: 50%;
   height: 300px;
@@ -107,16 +112,16 @@ p {
   padding: 10px;
   white-space: nowrap;
   overflow: auto;
-  }
-    .demo4 .box {
-      display: inline-block;
-      /* margin-right: 10px; */
-      width: 100px;
-      height: 150px;
-      text-align: center;
-      line-height: 150px;
-      font-size: 24px;
-      }
+}
+.demo4 .box {
+  display: inline-block;
+  /* margin-right: 10px; */
+  width: 100px;
+  height: 150px;
+  text-align: center;
+  line-height: 150px;
+  font-size: 24px;
+}
 .demo-raw {
   margin: 10px 0;
   width: 250px;

--- a/packages/simplebar/src/simplebar.css
+++ b/packages/simplebar/src/simplebar.css
@@ -115,6 +115,8 @@
 
 [data-simplebar].simplebar-dragging .simplebar-content {
   pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 [data-simplebar].simplebar-dragging .simplebar-track {

--- a/packages/simplebar/src/simplebar.css
+++ b/packages/simplebar/src/simplebar.css
@@ -113,6 +113,10 @@
   overflow: hidden;
 }
 
+[data-simplebar].simplebar-dragging .simplebar-content {
+  pointer-events: none;
+}
+
 [data-simplebar].simplebar-dragging .simplebar-track {
   pointer-events: all;
 }

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -381,19 +381,17 @@ export default class SimpleBar {
       this.el.addEventListener('mouseenter', this.onMouseEnter);
     }
 
-    [
-      'mousedown',
-      'click',
-      'dblclick',
-      'touchstart',
-      'touchend',
-      'touchmove'
-    ].forEach(e => {
+    ['mousedown', 'click', 'dblclick'].forEach(e => {
+      this.el.addEventListener(e, this.onPointerEvent, true);
+    });
+
+    ['touchstart', 'touchend', 'touchmove'].forEach(e => {
       this.el.addEventListener(e, this.onPointerEvent, {
         capture: true,
         passive: true
       });
     });
+
     this.el.addEventListener('mousemove', this.onMouseMove);
     this.el.addEventListener('mouseleave', this.onMouseLeave);
 
@@ -861,14 +859,11 @@ export default class SimpleBar {
       this.el.removeEventListener('mouseenter', this.onMouseEnter);
     }
 
-    [
-      'mousedown',
-      'click',
-      'dblclick',
-      'touchstart',
-      'touchend',
-      'touchmove'
-    ].forEach(e => {
+    ['mousedown', 'click', 'dblclick'].forEach(e => {
+      this.el.removeEventListener(e, this.onPointerEvent, true);
+    });
+
+    ['touchstart', 'touchend', 'touchmove'].forEach(e => {
       this.el.removeEventListener(e, this.onPointerEvent, {
         capture: true,
         passive: true


### PR DESCRIPTION
… content (fix #357)


@Demivan if you want to review!

I also separated the `onPointerEvents` in 2 so we avoid the `passive: true` on unnecessary events (which was triggering an error in Chrome).