### PR TITLE
chore: rework isOverflowing calculation

### DIFF
--- a/packages/simplebar/src/scrollbar-width.js
+++ b/packages/simplebar/src/scrollbar-width.js
@@ -5,6 +5,7 @@ export default function scrollbarWidth() {
 
   const body = document.body;
   const box = document.createElement('div');
+  box.classList.add('simplebar-hide-scrollbar');
   const boxStyle = box.style;
 
   boxStyle.position = 'fixed';

--- a/packages/simplebar/src/simplebar.css
+++ b/packages/simplebar/src/simplebar.css
@@ -55,6 +55,11 @@
   overflow: auto; /* Scroll on this element otherwise element can't have a padding applied properly */
   max-width: 100%; /* Not required for horizontal scroll to trigger */
   max-height: 100%; /* Needed for vertical scroll to trigger */
+  scrollbar-width: none;
+}
+
+.simplebar-content-wrapper::-webkit-scrollbar {
+  display: none;
 }
 
 .simplebar-content:before,
@@ -187,4 +192,12 @@
   width: 500px;
   overflow-y: hidden;
   overflow-x: scroll;
+}
+
+.simplebar-hide-scrollbar {
+  scrollbar-width: none;
+}
+
+.simplebar-hide-scrollbar::-webkit-scrollbar {
+  display: none;
 }

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -404,7 +404,15 @@ export default class SimpleBar {
     // Browser zoom triggers a window resize
     window.addEventListener('resize', this.onWindowResize);
 
-    this.resizeObserver = new ResizeObserver(this.recalculate);
+    // Hack for https://github.com/WICG/ResizeObserver/issues/38
+    let ignoredCallbacks = 0;
+
+    this.resizeObserver = new ResizeObserver(() => {
+      if (ignoredCallbacks < 2) return;
+      this.recalculate();
+      ignoredCallbacks++;
+    });
+
     this.resizeObserver.observe(this.el);
     this.resizeObserver.observe(this.contentEl);
   }

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -424,13 +424,9 @@ export default class SimpleBar {
     this.elStyles = window.getComputedStyle(this.el);
     this.isRtl = this.elStyles.direction === 'rtl';
 
-    this.contentEl.style.padding = `${this.elStyles.paddingTop} ${
-      this.elStyles.paddingRight
-    } ${this.elStyles.paddingBottom} ${this.elStyles.paddingLeft}`;
+    this.contentEl.style.padding = `${this.elStyles.paddingTop} ${this.elStyles.paddingRight} ${this.elStyles.paddingBottom} ${this.elStyles.paddingLeft}`;
 
-    this.wrapperEl.style.margin = `-${this.elStyles.paddingTop} -${
-      this.elStyles.paddingRight
-    } -${this.elStyles.paddingBottom} -${this.elStyles.paddingLeft}`;
+    this.wrapperEl.style.margin = `-${this.elStyles.paddingTop} -${this.elStyles.paddingRight} -${this.elStyles.paddingBottom} -${this.elStyles.paddingLeft}`;
 
     this.contentWrapperEl.style.height = isHeightAuto ? 'auto' : '100%';
 
@@ -472,9 +468,6 @@ export default class SimpleBar {
     this.axis.y.isOverflowing =
       this.contentEl.scrollHeight >
       this.contentWrapperEl.offsetHeight - offsetForXScrollbar;
-
-    this.axis.x.track.rect = this.axis.x.track.el.getBoundingClientRect();
-    this.axis.y.track.rect = this.axis.y.track.el.getBoundingClientRect();
 
     this.axis.x.scrollbar.size = this.getScrollbarSize('x');
     this.axis.y.scrollbar.size = this.getScrollbarSize('y');

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -29,6 +29,7 @@ export default class SimpleBar {
         scrollOffsetAttr: 'scrollLeft',
         sizeAttr: 'width',
         scrollSizeAttr: 'scrollWidth',
+        offsetSizeAttr: 'offsetWidth',
         offsetAttr: 'left',
         overflowAttr: 'overflowX',
         dragOffset: 0,
@@ -42,6 +43,7 @@ export default class SimpleBar {
         scrollOffsetAttr: 'scrollTop',
         sizeAttr: 'height',
         scrollSizeAttr: 'scrollHeight',
+        offsetSizeAttr: 'offsetHeight',
         offsetAttr: 'top',
         overflowAttr: 'overflowY',
         dragOffset: 0,
@@ -430,11 +432,10 @@ export default class SimpleBar {
       : 'auto';
     this.placeholderEl.style.height = `${this.contentEl.scrollHeight}px`;
 
-    // Set isOverflowing to false if scrollbar is not necessary (content is shorter than offset)
     this.axis.x.isOverflowing =
-      this.contentWrapperEl.scrollWidth > this.contentWrapperEl.offsetWidth;
+      this.contentEl.scrollWidth > this.contentEl.offsetWidth;
     this.axis.y.isOverflowing =
-      this.contentWrapperEl.scrollHeight > this.contentWrapperEl.offsetHeight;
+      this.contentEl.scrollHeight > this.contentWrapperEl.offsetHeight;
 
     // Set isOverflowing to false if user explicitely set hidden overflow
     this.axis.x.isOverflowing =
@@ -448,6 +449,21 @@ export default class SimpleBar {
       this.options.forceVisible === 'y' || this.options.forceVisible === true;
 
     this.hideNativeScrollbar();
+
+    // Set isOverflowing to false if scrollbar is not necessary (content is shorter than offset)
+    let offsetForXScrollbar = this.axis.x.isOverflowing
+      ? this.scrollbarWidth
+      : 0;
+    let offsetForYScrollbar = this.axis.y.isOverflowing
+      ? this.scrollbarWidth
+      : 0;
+
+    this.axis.x.isOverflowing =
+      this.contentEl.scrollWidth >
+      this.contentWrapperEl.offsetWidth - offsetForYScrollbar;
+    this.axis.y.isOverflowing =
+      this.contentEl.scrollHeight >
+      this.contentWrapperEl.offsetHeight - offsetForXScrollbar;
 
     this.axis.x.track.rect = this.axis.x.track.el.getBoundingClientRect();
     this.axis.y.track.rect = this.axis.y.track.el.getBoundingClientRect();
@@ -469,11 +485,8 @@ export default class SimpleBar {
    * Calculate scrollbar size
    */
   getScrollbarSize(axis = 'y') {
-    const contentSize = this.scrollbarWidth
-      ? this.contentWrapperEl[this.axis[axis].scrollSizeAttr]
-      : this.contentWrapperEl[this.axis[axis].scrollSizeAttr] -
-        this.minScrollbarWidth;
-    const trackSize = this.axis[axis].track.rect[this.axis[axis].sizeAttr];
+    const contentSize = this.contentEl[this.axis[axis].scrollSizeAttr];
+    const trackSize = this.axis[axis].track.el[this.axis[axis].offsetSizeAttr];
     let scrollbarSize;
 
     if (!this.axis[axis].isOverflowing) {
@@ -497,7 +510,7 @@ export default class SimpleBar {
 
   positionScrollbar(axis = 'y') {
     const contentSize = this.contentWrapperEl[this.axis[axis].scrollSizeAttr];
-    const trackSize = this.axis[axis].track.rect[this.axis[axis].sizeAttr];
+    const trackSize = this.axis[axis].track.el[this.axis[axis].offsetSizeAttr];
     const hostSize = parseInt(this.elStyles[this.axis[axis].sizeAttr], 10);
     const scrollbar = this.axis[axis].scrollbar;
 
@@ -547,25 +560,12 @@ export default class SimpleBar {
   hideNativeScrollbar() {
     this.offsetEl.style[this.isRtl ? 'left' : 'right'] =
       this.axis.y.isOverflowing || this.axis.y.forceVisible
-        ? `-${this.scrollbarWidth || this.minScrollbarWidth}px`
+        ? `-${this.scrollbarWidth}px`
         : 0;
     this.offsetEl.style.bottom =
       this.axis.x.isOverflowing || this.axis.x.forceVisible
-        ? `-${this.scrollbarWidth || this.minScrollbarWidth}px`
+        ? `-${this.scrollbarWidth}px`
         : 0;
-
-    // If floating scrollbar
-    if (!this.scrollbarWidth) {
-      const paddingDirection = [this.isRtl ? 'paddingLeft' : 'paddingRight'];
-      this.contentWrapperEl.style[paddingDirection] =
-        this.axis.y.isOverflowing || this.axis.y.forceVisible
-          ? `${this.minScrollbarWidth}px`
-          : 0;
-      this.contentWrapperEl.style.paddingBottom =
-        this.axis.x.isOverflowing || this.axis.x.forceVisible
-          ? `${this.minScrollbarWidth}px`
-          : 0;
-    }
   }
 
   /**


### PR DESCRIPTION
So I've been working on a new way to define the scrollbar `isOverflowing` state. Basically in some scenarios the scrollbar was showing when it wasn't necessary or the opposite, it wasn't showing.

The issue was basically with browsers that support floating scrollbars and have it activated (every modern browsers on mac for example and pretty much every mobile browsers).
On these browsers I'm now hiding the scrollbar in CSS. However there might be some browsers that support floating scrollbar (where the `scrollbarWidth() calculation returns `0`) but don't support hiding of the scrollbar in CSS? I'm not sure.

I summon @Demivan and @andersk to have a quick look and see if you see something obviously wrong here.
 