### PR TITLE
Allow for lazy initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ forceVisible: true|'x'|'y' (default to `false`)
 
 By default, SimpleBar behave like `overflow: auto`.
 
+#### lazyInitialization
+
+You can opt to have the necessary measurements and listeners added on the next tick, in order to optimize the display of the scrollable content.
+
+By default, this option is set to false.
+
 #### direction (RTL support)
 
 You can activate RTL support by passing the `direction` option:

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -273,7 +273,10 @@ export default class SimpleBar {
       }
 
       if (this.options.lazyInitialization) {
-        window.setTimeout(measureAndListen, 0)
+        this.lazyTimeout = window.setTimeout(() => {
+          this.lazyTimeout = null;
+          measureAndListen();
+        }, 0);
       } else {
         measureAndListen();
       }
@@ -904,7 +907,12 @@ export default class SimpleBar {
    * UnMount mutation observer and delete SimpleBar instance from DOM element
    */
   unMount() {
-    this.removeListeners();
+    if(this.lazyTimeout) {
+      window.clearTimeout(this.lazyTimeout);
+    } else {
+      this.removeListeners();
+    }
+  
     this.el.SimpleBar = null;
   }
 

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -104,8 +104,8 @@ export default class SimpleBar {
       isRtlScrollingInverted:
         dummyContainerOffset.left !== dummyContainerChildOffset.left &&
         dummyContainerChildOffset.left -
-        dummyContainerScrollOffsetAfterScroll.left !==
-        0,
+          dummyContainerScrollOffsetAfterScroll.left !==
+          0,
       // determines if the origin scrollbar position is inverted or not (positioned on left or right)
       isRtlScrollbarInverted:
         dummyContainerOffset.left !== dummyContainerChildOffset.left
@@ -266,13 +266,17 @@ export default class SimpleBar {
     if (canUseDOM) {
       this.initDOM();
 
-      function measureAndListen() {
+      const measureAndListen = () => {
         this.scrollbarWidth = scrollbarWidth();
         this.recalculate();
         this.initListeners();
-      }
+      };
 
       if (this.options.lazyInitialization) {
+        // If we are lazily initializing, then hide the native scrollbars now
+        // Otherwise there might be some flashing
+        this.hideNativeScrollbar();
+
         if (window.requestIdleCallback) {
           // In browsers that support it, wait for idle.
           this.lazyTimeout = window.requestIdleCallback(() => {
@@ -434,11 +438,11 @@ export default class SimpleBar {
 
     this.contentEl.style.padding = `${this.elStyles.paddingTop} ${
       this.elStyles.paddingRight
-      } ${this.elStyles.paddingBottom} ${this.elStyles.paddingLeft}`;
+    } ${this.elStyles.paddingBottom} ${this.elStyles.paddingLeft}`;
 
     this.wrapperEl.style.margin = `-${this.elStyles.paddingTop} -${
       this.elStyles.paddingRight
-      } -${this.elStyles.paddingBottom} -${this.elStyles.paddingLeft}`;
+    } -${this.elStyles.paddingBottom} -${this.elStyles.paddingLeft}`;
 
     this.contentWrapperEl.style.height = isHeightAuto ? 'auto' : '100%';
 
@@ -490,7 +494,7 @@ export default class SimpleBar {
     const contentSize = this.scrollbarWidth
       ? this.contentWrapperEl[this.axis[axis].scrollSizeAttr]
       : this.contentWrapperEl[this.axis[axis].scrollSizeAttr] -
-      this.minScrollbarWidth;
+        this.minScrollbarWidth;
     const trackSize = this.axis[axis].track.rect[this.axis[axis].sizeAttr];
     let scrollbarSize;
 
@@ -522,8 +526,8 @@ export default class SimpleBar {
     let scrollOffset = this.contentWrapperEl[this.axis[axis].scrollOffsetAttr];
     scrollOffset =
       axis === 'x' &&
-        this.isRtl &&
-        SimpleBar.getRtlHelpers().isRtlScrollingInverted
+      this.isRtl &&
+      SimpleBar.getRtlHelpers().isRtlScrollingInverted
         ? -scrollOffset
         : scrollOffset;
     let scrollPourcent = scrollOffset / (contentSize - hostSize);
@@ -531,8 +535,8 @@ export default class SimpleBar {
     let handleOffset = ~~((trackSize - scrollbar.size) * scrollPourcent);
     handleOffset =
       axis === 'x' &&
-        this.isRtl &&
-        SimpleBar.getRtlHelpers().isRtlScrollbarInverted
+      this.isRtl &&
+      SimpleBar.getRtlHelpers().isRtlScrollbarInverted
         ? handleOffset + (trackSize - scrollbar.size)
         : handleOffset;
 
@@ -916,11 +920,7 @@ export default class SimpleBar {
    */
   unMount() {
     if (this.lazyTimeout) {
-      if (window.cancelIdleCallback) {
-        window.cancelIdleCallback(this.lazyTimeout);
-      } else {
-        window.clearTimeout(this.lazyTimeout);
-      }
+      window.clearTimeout(this.lazyTimeout);
     } else {
       this.removeListeners();
     }

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -273,10 +273,18 @@ export default class SimpleBar {
       }
 
       if (this.options.lazyInitialization) {
-        this.lazyTimeout = window.setTimeout(() => {
-          this.lazyTimeout = null;
-          measureAndListen();
-        }, 0);
+        if (window.requestIdleCallback) {
+          // In browsers that support it, wait for idle.
+          this.lazyTimeout = window.requestIdleCallback(() => {
+            this.lazyTimeout = null;
+            measureAndListen();
+          });
+        } else {
+          this.lazyTimeout = window.setTimeout(() => {
+            this.lazyTimeout = null;
+            measureAndListen();
+          }, 0);
+        }
       } else {
         measureAndListen();
       }
@@ -907,12 +915,16 @@ export default class SimpleBar {
    * UnMount mutation observer and delete SimpleBar instance from DOM element
    */
   unMount() {
-    if(this.lazyTimeout) {
-      window.clearTimeout(this.lazyTimeout);
+    if (this.lazyTimeout) {
+      if (window.cancelIdleCallback) {
+        window.cancelIdleCallback(this.lazyTimeout);
+      } else {
+        window.clearTimeout(this.lazyTimeout);
+      }
     } else {
       this.removeListeners();
     }
-  
+
     this.el.SimpleBar = null;
   }
 

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -104,8 +104,8 @@ export default class SimpleBar {
       isRtlScrollingInverted:
         dummyContainerOffset.left !== dummyContainerChildOffset.left &&
         dummyContainerChildOffset.left -
-          dummyContainerScrollOffsetAfterScroll.left !==
-          0,
+        dummyContainerScrollOffsetAfterScroll.left !==
+        0,
       // determines if the origin scrollbar position is inverted or not (positioned on left or right)
       isRtlScrollbarInverted:
         dummyContainerOffset.left !== dummyContainerChildOffset.left
@@ -115,6 +115,7 @@ export default class SimpleBar {
   static defaultOptions = {
     autoHide: true,
     forceVisible: false,
+    lazyInitialization: false,
     classNames: {
       contentEl: 'simplebar-content',
       contentWrapper: 'simplebar-content-wrapper',
@@ -265,11 +266,17 @@ export default class SimpleBar {
     if (canUseDOM) {
       this.initDOM();
 
-      this.scrollbarWidth = scrollbarWidth();
+      function measureAndListen() {
+        this.scrollbarWidth = scrollbarWidth();
+        this.recalculate();
+        this.initListeners();
+      }
 
-      this.recalculate();
-
-      this.initListeners();
+      if (this.options.lazyInitialization) {
+        window.setTimeout(measureAndListen, 0)
+      } else {
+        measureAndListen();
+      }
     }
   }
 
@@ -416,11 +423,11 @@ export default class SimpleBar {
 
     this.contentEl.style.padding = `${this.elStyles.paddingTop} ${
       this.elStyles.paddingRight
-    } ${this.elStyles.paddingBottom} ${this.elStyles.paddingLeft}`;
+      } ${this.elStyles.paddingBottom} ${this.elStyles.paddingLeft}`;
 
     this.wrapperEl.style.margin = `-${this.elStyles.paddingTop} -${
       this.elStyles.paddingRight
-    } -${this.elStyles.paddingBottom} -${this.elStyles.paddingLeft}`;
+      } -${this.elStyles.paddingBottom} -${this.elStyles.paddingLeft}`;
 
     this.contentWrapperEl.style.height = isHeightAuto ? 'auto' : '100%';
 
@@ -472,7 +479,7 @@ export default class SimpleBar {
     const contentSize = this.scrollbarWidth
       ? this.contentWrapperEl[this.axis[axis].scrollSizeAttr]
       : this.contentWrapperEl[this.axis[axis].scrollSizeAttr] -
-        this.minScrollbarWidth;
+      this.minScrollbarWidth;
     const trackSize = this.axis[axis].track.rect[this.axis[axis].sizeAttr];
     let scrollbarSize;
 
@@ -504,8 +511,8 @@ export default class SimpleBar {
     let scrollOffset = this.contentWrapperEl[this.axis[axis].scrollOffsetAttr];
     scrollOffset =
       axis === 'x' &&
-      this.isRtl &&
-      SimpleBar.getRtlHelpers().isRtlScrollingInverted
+        this.isRtl &&
+        SimpleBar.getRtlHelpers().isRtlScrollingInverted
         ? -scrollOffset
         : scrollOffset;
     let scrollPourcent = scrollOffset / (contentSize - hostSize);
@@ -513,8 +520,8 @@ export default class SimpleBar {
     let handleOffset = ~~((trackSize - scrollbar.size) * scrollPourcent);
     handleOffset =
       axis === 'x' &&
-      this.isRtl &&
-      SimpleBar.getRtlHelpers().isRtlScrollbarInverted
+        this.isRtl &&
+        SimpleBar.getRtlHelpers().isRtlScrollbarInverted
         ? handleOffset + (trackSize - scrollbar.size)
         : handleOffset;
 


### PR DESCRIPTION
`recalculate` always causes a reflow. In complex DOM environments, this reflow can be very expensive and delays the initial render of the content.

Introduce an option `lazyInitialization`, which delays the adding of listeners until the next idle callback (or next tick if the browser does not support `requestIdleCallback`). This optimizes the first paint experience

See #371 