### PR TITLE
fix: add window check before addEventListener

### DIFF
--- a/packages/simplebar/src/scrollbar-width.js
+++ b/packages/simplebar/src/scrollbar-width.js
@@ -1,12 +1,14 @@
 let cachedScrollbarWidth = null;
 let cachedDevicePixelRatio = null;
 
-window.addEventListener('resize', () => {
-  if (cachedDevicePixelRatio !== window.devicePixelRatio) {
-    cachedDevicePixelRatio = window.devicePixelRatio;
-    cachedScrollbarWidth = null;
-  }
-});
+if (typeof window !== 'undefined') {
+  window.addEventListener('resize', () => {
+    if (cachedDevicePixelRatio !== window.devicePixelRatio) {
+      cachedDevicePixelRatio = window.devicePixelRatio;
+      cachedScrollbarWidth = null;
+    }
+  });
+}
 
 export default function scrollbarWidth() {
   if (cachedScrollbarWidth === null) {

--- a/packages/simplebar/src/scrollbar-width.js
+++ b/packages/simplebar/src/scrollbar-width.js
@@ -1,7 +1,9 @@
+import canUseDOM from 'can-use-dom';
+
 let cachedScrollbarWidth = null;
 let cachedDevicePixelRatio = null;
 
-if (typeof window !== 'undefined') {
+if (canUseDOM) {
   window.addEventListener('resize', () => {
     if (cachedDevicePixelRatio !== window.devicePixelRatio) {
       cachedDevicePixelRatio = window.devicePixelRatio;


### PR DESCRIPTION
In scrollbar-width.js, the code was doing window.addEventListener even when window was undefined.
This broke simplebar in SSR environments.
This commits adds a check before trying to add the resize event.