### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/packages/simplebar-react/README.md
+++ b/packages/simplebar-react/README.md
@@ -33,7 +33,9 @@ import SimpleBar from 'simplebar-react';
 import 'simplebar/dist/simplebar.min.css';
 
 const App = () => (
-  <SimpleBar style={{ maxHeight: 300 }}>// your content</SimpleBar>
+  <SimpleBar style={{ maxHeight: 300 }}>
+    // your content
+  </SimpleBar>
 );
 ```
 


### PR DESCRIPTION
The inline comment was causing GitHub's syntax highlighter to grey out the closing tag `</SimpleBar>`:

<img width="709" alt="Screen Shot 2019-10-23 at 3 37 12 PM" src="https://user-images.githubusercontent.com/69485/67439461-1dd19d00-f5ab-11e9-9810-e9356451e76b.png">
