### PR TITLE
Nested selector workaround in react

### DIFF
--- a/packages/simplebar-react/index.js
+++ b/packages/simplebar-react/index.js
@@ -94,6 +94,7 @@ const SimpleBar = React.forwardRef(
     return (
       <div ref={elRef} {...rest}>
         <div className="simplebar-wrapper">
+          <div className="simplebar-placeholder" />
           <div className="simplebar-height-auto-observer-wrapper">
             <div className="simplebar-height-auto-observer" />
           </div>
@@ -115,7 +116,6 @@ const SimpleBar = React.forwardRef(
               )}
             </div>
           </div>
-          <div className="simplebar-placeholder" />
         </div>
         <div className="simplebar-track simplebar-horizontal">
           <div className="simplebar-scrollbar" />


### PR DESCRIPTION
Same problem as [here](https://github.com/Grsmto/simplebar/pull/348) but with `simplebar-placeholder` selector. Parent simplebar selects `simplebar-placeholder` from it's nested child simplebar [here](https://github.com/Grsmto/simplebar/blob/master/packages/simplebar/src/simplebar.js#L180).
Here is an example: https://jsfiddle.net/e5hufs3o/17/