### PR TITLE
Remove some window/document globals

### DIFF
--- a/packages/simplebar/demo/Demo.js
+++ b/packages/simplebar/demo/Demo.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createPortal } from 'react-dom';
+import ReactDOM, { createPortal } from 'react-dom';
 import Select from 'react-select';
 import { FixedSizeList as List } from 'react-window';
 import SimpleBarReact from 'simplebar-react';
@@ -26,6 +26,7 @@ const renderScrollbar = props => {
 const Demo = () => {
   const [isHidden, setHidden] = React.useState(true);
   // const scrollableElRef = React.createRef();
+  const [showWindowPortal, setShowWindowPortal] = React.useState(false);
 
   const handleShowClick = React.useCallback(() => {
     setHidden(false);
@@ -349,115 +350,49 @@ const Demo = () => {
           </SimpleBarReact>
         </div>
       </section>
+      <section>
+        <div className="col">
+          <h2>Render into portal window</h2>
+          <button onClick={() => setShowWindowPortal(true)}>
+            Open the window
+          </button>
+          {showWindowPortal && (
+            <WindowPortal>
+              <SimpleBarReact
+                style={{ height: 300, width: 50, overflowY: 'scroll' }}
+              >
+                {[...Array(10)].map((x, i) => (
+                  <p key={i} className="odd">
+                    Some content
+                  </p>
+                ))}
+              </SimpleBarReact>
+            </WindowPortal>
+          )}
+        </div>
+      </section>
     </section>
   );
 };
 
-class ScrollContainer extends React.Component {
-  componentDidMount() {
-    this.simpleBar = new SimpleBar(this.scrollElementRef, {
-      autoHide: false
-    });
-  }
-
-  render() {
-    return (
-      <div
-        ref={ref => {
-          if (ref && !this.scrollElementRef) {
-            this.scrollElementRef = ref;
-          }
-        }}
-        data-simplebar
-      >
-        {this.props.children}
-      </div>
-    );
-  }
-}
-
-class IFrame extends React.Component {
+class WindowPortal extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = {
-      iframeLoaded: false
-    };
+    this.containerEl = document.createElement('div');
+    this.externalWindow = null;
   }
 
   render() {
-    return (
-      <iframe
-        ref={ref => {
-          if (ref && ref.contentWindow && !this.state.iframeLoaded) {
-            this.contentRef = ref.contentWindow.document.body;
-            this.setState({
-              iframeLoaded: true
-            });
-          }
-        }}
-      >
-        {this.contentRef &&
-          this.state.iframeLoaded &&
-          createPortal(
-            React.Children.only(this.props.children),
-            this.contentRef
-          )}
-      </iframe>
-    );
+    return ReactDOM.createPortal(this.props.children, this.containerEl);
   }
-}
 
-class ScrollContainer extends React.Component {
   componentDidMount() {
-    this.simpleBar = new SimpleBar(this.scrollElementRef, {
-      autoHide: false
-    });
+    this.externalWindow = window.open();
+    this.externalWindow.document.body.appendChild(this.containerEl);
   }
 
-  render() {
-    return (
-      <div
-        ref={ref => {
-          if (ref && !this.scrollElementRef) {
-            this.scrollElementRef = ref;
-          }
-        }}
-        data-simplebar
-      >
-        {this.props.children}
-      </div>
-    );
-  }
-}
-
-class IFrame extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      iframeLoaded: false
-    };
-  }
-
-  render() {
-    return (
-      <iframe
-        ref={ref => {
-          if (ref && ref.contentWindow && !this.state.iframeLoaded) {
-            this.contentRef = ref.contentWindow.document.body;
-            this.setState({
-              iframeLoaded: true
-            });
-          }
-        }}
-      >
-        {this.contentRef &&
-          this.state.iframeLoaded &&
-          createPortal(
-            React.Children.only(this.props.children),
-            this.contentRef
-          )}
-      </iframe>
-    );
+  componentWillUnmount() {
+    this.externalWindow.close();
   }
 }
 

--- a/packages/simplebar/demo/Demo.js
+++ b/packages/simplebar/demo/Demo.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import Select from 'react-select';
 import { FixedSizeList as List } from 'react-window';
 import SimpleBarReact from 'simplebar-react';
@@ -351,5 +352,61 @@ const Demo = () => {
     </section>
   );
 };
+
+class ScrollContainer extends React.Component {
+  componentDidMount() {
+    this.simpleBar = new SimpleBar(this.scrollElementRef, {
+      autoHide: false
+    });
+  }
+
+  render() {
+    return (
+      <div
+        ref={ref => {
+          if (ref && !this.scrollElementRef) {
+            this.scrollElementRef = ref;
+          }
+        }}
+        data-simplebar
+      >
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+class IFrame extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      ifameLoaded: false
+    };
+  }
+
+  render() {
+    return (
+      <iframe
+        ref={ref => {
+          if (ref && ref.contentWindow && !this.state.iframeLoaded) {
+            console.log('set ref');
+            console.log(ref.contentWindow.document.body);
+            this.contentRef = ref.contentWindow.document.body;
+            this.setState({
+              iframeLoaded: true
+            });
+          }
+        }}
+      >
+        {this.contentRef &&
+          this.state.iframeLoaded &&
+          createPortal(
+            React.Children.only(this.props.children),
+            this.contentRef
+          )}
+      </iframe>
+    );
+  }
+}
 
 export default Demo;

--- a/packages/simplebar/demo/Demo.js
+++ b/packages/simplebar/demo/Demo.js
@@ -380,7 +380,7 @@ class IFrame extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      ifameLoaded: false
+      iframeLoaded: false
     };
   }
 
@@ -389,8 +389,6 @@ class IFrame extends React.Component {
       <iframe
         ref={ref => {
           if (ref && ref.contentWindow && !this.state.iframeLoaded) {
-            console.log('set ref');
-            console.log(ref.contentWindow.document.body);
             this.contentRef = ref.contentWindow.document.body;
             this.setState({
               iframeLoaded: true

--- a/packages/simplebar/demo/Demo.js
+++ b/packages/simplebar/demo/Demo.js
@@ -352,14 +352,13 @@ const Demo = () => {
       <section>
         <div className="col">
           <h2>Render into iframe</h2>
-          <IFrame>
+          <IFrame width="800" height="600">
             <ScrollContainer>
-              {[...Array(10)].map((x, i) => (
+              {[...Array(30)].map((x, i) => (
                 <p key={i}>Some content</p>
               ))}
             </ScrollContainer>
           </IFrame>
-          )}
         </div>
       </section>
     </section>
@@ -368,16 +367,13 @@ const Demo = () => {
 
 class ScrollContainer extends React.Component {
   componentDidMount() {
-    this.simpleBar = new SimpleBar(this.scrollElementRef, {
-      autoHide: false
-    });
+    this.simpleBar = new SimpleBar(this.scrollElementRef);
   }
 
   render() {
     return (
       <div
         style={{
-          width: 500,
           height: 300,
           overflowY: 'scroll'
         }}
@@ -405,9 +401,17 @@ class IFrame extends React.Component {
   render() {
     return (
       <iframe
+        height={this.props.height}
+        width={this.props.width}
         ref={ref => {
           if (ref && ref.contentWindow && !this.state.iframeLoaded) {
             this.contentRef = ref.contentWindow.document.body;
+            [
+              ...document.head.querySelectorAll('link'),
+              ...document.head.querySelectorAll('style')
+            ].forEach(tag => {
+              ref.contentWindow.document.head.innerHTML += tag.outerHTML;
+            });
             this.setState({
               iframeLoaded: true
             });

--- a/packages/simplebar/demo/Demo.js
+++ b/packages/simplebar/demo/Demo.js
@@ -26,7 +26,6 @@ const renderScrollbar = props => {
 const Demo = () => {
   const [isHidden, setHidden] = React.useState(true);
   // const scrollableElRef = React.createRef();
-  const [showWindowPortal, setShowWindowPortal] = React.useState(false);
 
   const handleShowClick = React.useCallback(() => {
     setHidden(false);
@@ -425,3 +424,5 @@ class IFrame extends React.Component {
     );
   }
 }
+
+export default Demo;

--- a/packages/simplebar/src/helpers.js
+++ b/packages/simplebar/src/helpers.js
@@ -26,3 +26,21 @@ export const getOptions = function(obj) {
   );
   return options;
 };
+
+export function getElementWindow(element) {
+  if (
+    !element ||
+    !element.ownerDocument ||
+    !element.ownerDocument.defaultView
+  ) {
+    return window;
+  }
+  return element.ownerDocument.defaultView;
+}
+
+export function getElementDocument(element) {
+  if (!element || !element.ownerDocument) {
+    return document;
+  }
+  return element.ownerDocument;
+}

--- a/packages/simplebar/src/scrollbar-width.js
+++ b/packages/simplebar/src/scrollbar-width.js
@@ -1,4 +1,5 @@
 import canUseDOM from 'can-use-dom';
+import { getElementWindow, getElementDocument } from './helpers';
 
 let cachedScrollbarWidth = null;
 let cachedDevicePixelRatio = null;
@@ -12,15 +13,16 @@ if (canUseDOM) {
   });
 }
 
-export default function scrollbarWidth() {
+export default function scrollbarWidth(element) {
+  const elementDocument = getElementDocument(element);
   if (cachedScrollbarWidth === null) {
-    if (typeof document === 'undefined') {
+    if (typeof elementDocument === 'undefined') {
       cachedScrollbarWidth = 0;
       return cachedScrollbarWidth;
     }
 
-    const body = document.body;
-    const box = document.createElement('div');
+    const body = elementDocument.body;
+    const box = elementDocument.createElement('div');
 
     box.classList.add('simplebar-hide-scrollbar');
 

--- a/packages/simplebar/src/scrollbar-width.js
+++ b/packages/simplebar/src/scrollbar-width.js
@@ -1,5 +1,5 @@
 import canUseDOM from 'can-use-dom';
-import { getElementWindow, getElementDocument } from './helpers';
+import { getElementDocument } from './helpers';
 
 let cachedScrollbarWidth = null;
 let cachedDevicePixelRatio = null;

--- a/packages/simplebar/src/scrollbar-width.js
+++ b/packages/simplebar/src/scrollbar-width.js
@@ -1,5 +1,4 @@
 import canUseDOM from 'can-use-dom';
-import { getElementDocument } from './helpers';
 
 let cachedScrollbarWidth = null;
 let cachedDevicePixelRatio = null;
@@ -13,16 +12,15 @@ if (canUseDOM) {
   });
 }
 
-export default function scrollbarWidth(element) {
-  const elementDocument = getElementDocument(element);
+export default function scrollbarWidth() {
   if (cachedScrollbarWidth === null) {
     if (typeof elementDocument === 'undefined') {
       cachedScrollbarWidth = 0;
       return cachedScrollbarWidth;
     }
 
-    const body = elementDocument.body;
-    const box = elementDocument.createElement('div');
+    const body = document.body;
+    const box = document.createElement('div');
 
     box.classList.add('simplebar-hide-scrollbar');
 

--- a/packages/simplebar/src/scrollbar-width.js
+++ b/packages/simplebar/src/scrollbar-width.js
@@ -14,7 +14,7 @@ if (canUseDOM) {
 
 export default function scrollbarWidth() {
   if (cachedScrollbarWidth === null) {
-    if (typeof elementDocument === 'undefined') {
+    if (typeof document === 'undefined') {
       cachedScrollbarWidth = 0;
       return cachedScrollbarWidth;
     }

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -155,7 +155,7 @@ export default class SimpleBar {
     if (canUseDOM) {
       this.initDOM();
 
-      this.scrollbarWidth = this.getScrollbarWidth(this.el);
+      this.scrollbarWidth = this.getScrollbarWidth();
 
       this.recalculate();
 
@@ -466,6 +466,7 @@ export default class SimpleBar {
     const scrollbar = this.axis[axis].scrollbar.el;
 
     if (this.axis[axis].isOverflowing || this.axis[axis].forceVisible) {
+      console.log(`${axis} is overflowing!!`);
       track.style.visibility = 'visible';
       this.contentWrapperEl.style[this.axis[axis].overflowAttr] = 'scroll';
     } else {

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -466,7 +466,6 @@ export default class SimpleBar {
     const scrollbar = this.axis[axis].scrollbar.el;
 
     if (this.axis[axis].isOverflowing || this.axis[axis].forceVisible) {
-      console.log(`${axis} is overflowing!!`);
       track.style.visibility = 'visible';
       this.contentWrapperEl.style[this.axis[axis].overflowAttr] = 'scroll';
     } else {

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -203,14 +203,14 @@ export default class SimpleBar {
       );
     } else {
       // Prepare DOM
-      this.wrapperEl = elDocument.createElement('div');
-      this.contentWrapperEl = elDocument.createElement('div');
-      this.offsetEl = elDocument.createElement('div');
-      this.maskEl = elDocument.createElement('div');
-      this.contentEl = elDocument.createElement('div');
-      this.placeholderEl = elDocument.createElement('div');
-      this.heightAutoObserverWrapperEl = elDocument.createElement('div');
-      this.heightAutoObserverEl = elDocument.createElement('div');
+      this.wrapperEl = document.createElement('div');
+      this.contentWrapperEl = document.createElement('div');
+      this.offsetEl = document.createElement('div');
+      this.maskEl = document.createElement('div');
+      this.contentEl = document.createElement('div');
+      this.placeholderEl = document.createElement('div');
+      this.heightAutoObserverWrapperEl = document.createElement('div');
+      this.heightAutoObserverEl = document.createElement('div');
 
       this.wrapperEl.classList.add(this.classNames.wrapper);
       this.contentWrapperEl.classList.add(this.classNames.contentWrapper);
@@ -240,8 +240,8 @@ export default class SimpleBar {
     }
 
     if (!this.axis.x.track.el || !this.axis.y.track.el) {
-      const track = elDocument.createElement('div');
-      const scrollbar = elDocument.createElement('div');
+      const track = document.createElement('div');
+      const scrollbar = document.createElement('div');
 
       track.classList.add(this.classNames.track);
       scrollbar.classList.add(this.classNames.scrollbar);
@@ -843,14 +843,13 @@ export default class SimpleBar {
   }
 
   getScrollbarWidth() {
-    const elDocument = getElementDocument(this.el);
     // Try/catch for FF 56 throwing on undefined computedStyles
     try {
       // Detect Chrome/Firefox and do not calculate
       if (
         getComputedStyle(this.contentWrapperEl, '::-webkit-scrollbar')
           .display === 'none' ||
-        'scrollbarWidth' in elDocument.documentElement.style
+        'scrollbarWidth' in document.documentElement.style
       ) {
         return 0;
       } else {

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -4,6 +4,7 @@ import memoize from 'lodash.memoize';
 import ResizeObserver from 'resize-observer-polyfill';
 import canUseDOM from 'can-use-dom';
 import scrollbarWidth from './scrollbar-width';
+import { getElementWindow, getElementDocument } from './helpers';
 
 export default class SimpleBar {
   constructor(element, options) {
@@ -131,12 +132,16 @@ export default class SimpleBar {
 
   static getOffset(el) {
     const rect = el.getBoundingClientRect();
+    const elDocument = getElementDocument(el);
+    const elWindow = getElementWindow(el);
 
     return {
       top:
-        rect.top + (window.pageYOffset || document.documentElement.scrollTop),
+        rect.top +
+        (elwindow.pageYOffset || elDocument.documentElement.scrollTop),
       left:
-        rect.left + (window.pageXOffset || document.documentElement.scrollLeft)
+        rect.left +
+        (elWindow.pageXOffset || elDocument.documentElement.scrollLeft)
     };
   }
 
@@ -150,7 +155,7 @@ export default class SimpleBar {
     if (canUseDOM) {
       this.initDOM();
 
-      this.scrollbarWidth = this.getScrollbarWidth();
+      this.scrollbarWidth = this.getScrollbarWidth(this.el);
 
       this.recalculate();
 
@@ -159,6 +164,7 @@ export default class SimpleBar {
   }
 
   initDOM() {
+    const elDocument = getElementDocument(this.el);
     // make sure this element doesn't have the elements yet
     if (
       Array.prototype.filter.call(this.el.children, child =>
@@ -197,14 +203,14 @@ export default class SimpleBar {
       );
     } else {
       // Prepare DOM
-      this.wrapperEl = document.createElement('div');
-      this.contentWrapperEl = document.createElement('div');
-      this.offsetEl = document.createElement('div');
-      this.maskEl = document.createElement('div');
-      this.contentEl = document.createElement('div');
-      this.placeholderEl = document.createElement('div');
-      this.heightAutoObserverWrapperEl = document.createElement('div');
-      this.heightAutoObserverEl = document.createElement('div');
+      this.wrapperEl = elDocument.createElement('div');
+      this.contentWrapperEl = elDocument.createElement('div');
+      this.offsetEl = elDocument.createElement('div');
+      this.maskEl = elDocument.createElement('div');
+      this.contentEl = elDocument.createElement('div');
+      this.placeholderEl = elDocument.createElement('div');
+      this.heightAutoObserverWrapperEl = elDocument.createElement('div');
+      this.heightAutoObserverEl = elDocument.createElement('div');
 
       this.wrapperEl.classList.add(this.classNames.wrapper);
       this.contentWrapperEl.classList.add(this.classNames.contentWrapper);
@@ -234,8 +240,8 @@ export default class SimpleBar {
     }
 
     if (!this.axis.x.track.el || !this.axis.y.track.el) {
-      const track = document.createElement('div');
-      const scrollbar = document.createElement('div');
+      const track = elDocument.createElement('div');
+      const scrollbar = elDocument.createElement('div');
 
       track.classList.add(this.classNames.track);
       scrollbar.classList.add(this.classNames.scrollbar);
@@ -268,6 +274,7 @@ export default class SimpleBar {
   }
 
   initListeners() {
+    const elWindow = getElementWindow(this.el);
     // Event listeners
     if (this.options.autoHide) {
       this.el.addEventListener('mouseenter', this.onMouseEnter);
@@ -290,12 +297,11 @@ export default class SimpleBar {
     this.contentWrapperEl.addEventListener('scroll', this.onScroll);
 
     // Browser zoom triggers a window resize
-    window.addEventListener('resize', this.onWindowResize);
+    elWindow.addEventListener('resize', this.onWindowResize);
 
     // Hack for https://github.com/WICG/ResizeObserver/issues/38
     let resizeObserverStarted = false;
-
-    this.resizeObserver = new ResizeObserver(() => {
+    this.resizeObserver = new elWindow.ResizeObserver(() => {
       if (!resizeObserverStarted) return;
       this.recalculate();
     });
@@ -303,12 +309,12 @@ export default class SimpleBar {
     this.resizeObserver.observe(this.el);
     this.resizeObserver.observe(this.contentEl);
 
-    window.requestAnimationFrame(() => {
+    elWindow.requestAnimationFrame(() => {
       resizeObserverStarted = true;
     });
 
     // This is required to detect horizontal scroll. Vertical scroll only needs the resizeObserver.
-    this.mutationObserver = new MutationObserver(this.recalculate);
+    this.mutationObserver = new elWindow.MutationObserver(this.recalculate);
 
     this.mutationObserver.observe(this.contentEl, {
       childList: true,
@@ -318,7 +324,8 @@ export default class SimpleBar {
   }
 
   recalculate() {
-    this.elStyles = window.getComputedStyle(this.el);
+    const elWindow = getElementWindow(this.el);
+    this.elStyles = elWindow.getComputedStyle(this.el);
     this.isRtl = this.elStyles.direction === 'rtl';
 
     const isHeightAuto = this.heightAutoObserverEl.offsetHeight <= 1;
@@ -488,13 +495,14 @@ export default class SimpleBar {
    * On scroll event handling
    */
   onScroll = () => {
+    const elWindow = getElementWindow(this.el);
     if (!this.scrollXTicking) {
-      window.requestAnimationFrame(this.scrollX);
+      elWindow.requestAnimationFrame(this.scrollX);
       this.scrollXTicking = true;
     }
 
     if (!this.scrollYTicking) {
-      window.requestAnimationFrame(this.scrollY);
+      elWindow.requestAnimationFrame(this.scrollY);
       this.scrollYTicking = true;
     }
   };
@@ -672,6 +680,8 @@ export default class SimpleBar {
    * on scrollbar handle drag movement starts
    */
   onDragStart(e, axis = 'y') {
+    const elDocument = getElementDocument(this.el);
+    const elWindow = getElementWindow(this.el);
     const scrollbar = this.axis[axis].scrollbar;
 
     // Measure how far the user's mouse is from the top of the scrollbar drag handle.
@@ -682,13 +692,13 @@ export default class SimpleBar {
 
     this.el.classList.add(this.classNames.dragging);
 
-    document.addEventListener('mousemove', this.drag, true);
-    document.addEventListener('mouseup', this.onEndDrag, true);
+    elDocument.addEventListener('mousemove', this.drag, true);
+    elDocument.addEventListener('mouseup', this.onEndDrag, true);
     if (this.removePreventClickId === null) {
-      document.addEventListener('click', this.preventClick, true);
-      document.addEventListener('dblclick', this.preventClick, true);
+      elDocument.addEventListener('click', this.preventClick, true);
+      elDocument.addEventListener('dblclick', this.preventClick, true);
     } else {
-      window.clearTimeout(this.removePreventClickId);
+      elWindow.clearTimeout(this.removePreventClickId);
       this.removePreventClickId = null;
     }
   }
@@ -750,18 +760,20 @@ export default class SimpleBar {
    * End scroll handle drag
    */
   onEndDrag = e => {
+    const elDocument = getElementDocument(this.el);
+    const elWindow = getElementWindow(this.el);
     e.preventDefault();
     e.stopPropagation();
 
     this.el.classList.remove(this.classNames.dragging);
 
-    document.removeEventListener('mousemove', this.drag, true);
-    document.removeEventListener('mouseup', this.onEndDrag, true);
-    this.removePreventClickId = window.setTimeout(() => {
+    elDocument.removeEventListener('mousemove', this.drag, true);
+    elDocument.removeEventListener('mouseup', this.onEndDrag, true);
+    this.removePreventClickId = elWindow.setTimeout(() => {
       // Remove these asynchronously so we still suppress click events
       // generated simultaneously with mouseup.
-      document.removeEventListener('click', this.preventClick, true);
-      document.removeEventListener('dblclick', this.preventClick, true);
+      elDocument.removeEventListener('click', this.preventClick, true);
+      elDocument.removeEventListener('dblclick', this.preventClick, true);
       this.removePreventClickId = null;
     });
   };
@@ -775,6 +787,7 @@ export default class SimpleBar {
   };
 
   onTrackClick(e, axis = 'y') {
+    const elWindow = getElementWindow(this.el);
     this.axis[axis].scrollbar.rect = this.axis[
       axis
     ].scrollbar.el.getBoundingClientRect();
@@ -797,7 +810,7 @@ export default class SimpleBar {
           this.contentWrapperEl.scrollTo({
             [this.axis[axis].offsetAttr]: scrolled
           });
-          window.requestAnimationFrame(scrollTo);
+          elWindow.requestAnimationFrame(scrollTo);
         }
       } else {
         if (scrolled < scrollSize) {
@@ -805,7 +818,7 @@ export default class SimpleBar {
           this.contentWrapperEl.scrollTo({
             [this.axis[axis].offsetAttr]: scrolled
           });
-          window.requestAnimationFrame(scrollTo);
+          elWindow.requestAnimationFrame(scrollTo);
         }
       }
     };
@@ -828,13 +841,14 @@ export default class SimpleBar {
   }
 
   getScrollbarWidth() {
+    const elDocument = getElementDocument(this.el);
     // Try/catch for FF 56 throwing on undefined computedStyles
     try {
       // Detect Chrome/Firefox and do not calculate
       if (
         getComputedStyle(this.contentWrapperEl, '::-webkit-scrollbar')
           .display === 'none' ||
-        'scrollbarWidth' in document.documentElement.style
+        'scrollbarWidth' in elDocument.documentElement.style
       ) {
         return 0;
       } else {
@@ -846,6 +860,7 @@ export default class SimpleBar {
   }
 
   removeListeners() {
+    const elWindow = getElementWindow(this.el);
     // Event listeners
     if (this.options.autoHide) {
       this.el.removeEventListener('mouseenter', this.onMouseEnter);
@@ -866,7 +881,7 @@ export default class SimpleBar {
     this.el.removeEventListener('mouseleave', this.onMouseLeave);
 
     this.contentWrapperEl.removeEventListener('scroll', this.onScroll);
-    window.removeEventListener('resize', this.onWindowResize);
+    elWindow.removeEventListener('resize', this.onWindowResize);
 
     this.mutationObserver.disconnect();
     this.resizeObserver.disconnect();

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -138,7 +138,7 @@ export default class SimpleBar {
     return {
       top:
         rect.top +
-        (elwindow.pageYOffset || elDocument.documentElement.scrollTop),
+        (elWindow.pageYOffset || elDocument.documentElement.scrollTop),
       left:
         rect.left +
         (elWindow.pageXOffset || elDocument.documentElement.scrollLeft)
@@ -301,7 +301,8 @@ export default class SimpleBar {
 
     // Hack for https://github.com/WICG/ResizeObserver/issues/38
     let resizeObserverStarted = false;
-    this.resizeObserver = new elWindow.ResizeObserver(() => {
+    const resizeObserver = elWindow.ResizeObserver || ResizeObserver;
+    this.resizeObserver = new resizeObserver(() => {
       if (!resizeObserverStarted) return;
       this.recalculate();
     });


### PR DESCRIPTION
Addresses #394 -- where possible replaces `window` and `document` globals with `el.ownerDocument.defaultView` and `el.ownerDocument`, respectively. This gives more flexibility to the library, for example letting you render a `SimpleBar` on an element inside an `iframe`, from some JavaScript running in the document containing the `iframe`.