### PR TITLE
Set '-ms-overflow-style: scrollbar' on the scrollbar sizer element

### DIFF
--- a/packages/simplebar/src/simplebar.css
+++ b/packages/simplebar/src/simplebar.css
@@ -206,4 +206,5 @@
   visibility: hidden;
   overflow-y: scroll;
   scrollbar-width: none;
+  -ms-overflow-style: scrollbar;
 }


### PR DESCRIPTION
The default overflow style on tablets (for example the Microsoft Surface) is"-ms-autohiding-scrollbar". That causes simplebar to miscalculate the sidebar size (width:0) and that causes the native scroll bar to remain visible.

You can easily see that by visiting the simplebar homepage on Microsoft Surface, using the Edge browser.