### PR TITLE
Fix angular SSR issues

### DIFF
--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -885,11 +885,19 @@ export default class SimpleBar {
     this.el.removeEventListener('mousemove', this.onMouseMove);
     this.el.removeEventListener('mouseleave', this.onMouseLeave);
 
-    this.contentWrapperEl.removeEventListener('scroll', this.onScroll);
+    if (this.contentWrapperEl) {
+      this.contentWrapperEl.removeEventListener('scroll', this.onScroll);
+    }
+
     elWindow.removeEventListener('resize', this.onWindowResize);
 
-    this.mutationObserver.disconnect();
-    this.resizeObserver.disconnect();
+    if (this.mutationObserver) {
+      this.mutationObserver.disconnect();
+    }
+
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    }
 
     // Cancel all debounced functions
     this.recalculate.cancel();


### PR DESCRIPTION
I'm using SSR with Angular 7, and after I have added simplebar for angular, on SSR I'm getting an error:
`Error generating html for req /roadmap TypeError: Cannot read property 'removeEventListener' of undefined
    at SimpleBar.removeListeners (...\dist\server.js:267875:27)
    at SimpleBar.unMount (...\dist\server.js:267895:10)
    at SimplebarAngularComponent.module.exports.SimplebarAngularComponent.ngOnDestroy (...\dist\server.js:267988:24)`

In the PR I have just added if checks for the existence of used vars. With this PR SSR works fine for me.

It's also reproducible on 2.2 and 3.0 versions of the plugin for Angular,