### PR TITLE
build(npm): include all css files in `sideEffects`

### DIFF
--- a/packages/simplebar-react/package.json
+++ b/packages/simplebar-react/package.json
@@ -15,6 +15,7 @@
   "main": "dist/simplebar-react.js",
   "module": "dist/simplebar-react.esm.js",
   "types": "dist/simplebar-react.d.ts",
+  "sideEffects": ["*.css"],
   "bugs": "https://github.com/grsmto/simplebar/issues",
   "homepage": "https://grsmto.github.io/simplebar/",
   "license": "MIT",


### PR DESCRIPTION
It should fix gatsby not including `simplebar-react/dist/simplebar.min.css` in production build.

Closes #511