### PR TITLE
Fix offset mismatch in isOverflowing calculation

### DIFF
--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -382,11 +382,11 @@ export default class SimpleBar {
 
     this.axis.x.isOverflowing =
       this.axis.x.isOverflowing &&
-      contentElScrollWidth > contentWrapperElOffsetWidth - offsetForYScrollbar;
+      contentElScrollWidth > contentWrapperElOffsetWidth - offsetForXScrollbar;
     this.axis.y.isOverflowing =
       this.axis.y.isOverflowing &&
       contentElScrollHeight >
-        contentWrapperElOffsetHeight - offsetForXScrollbar;
+        contentWrapperElOffsetHeight - offsetForYScrollbar;
 
     this.axis.x.scrollbar.size = this.getScrollbarSize('x');
     this.axis.y.scrollbar.size = this.getScrollbarSize('y');


### PR DESCRIPTION
Used this.offsetForYScrollbar in computing if X isOverflowing and vice-versa