### PR TITLE
[Vue package] Fix: exception about undefined scroll listener

### DIFF
--- a/packages/simplebar-vue/index.vue
+++ b/packages/simplebar-vue/index.vue
@@ -9,7 +9,11 @@
           <div
             class="simplebar-content-wrapper"
             ref="scrollElement"
-            @scroll="$listeners.scroll"
+            v-on="{
+              ...($listeners.scroll && {
+                scroll: $listeners.scroll,
+              })
+            }"
           >
             <div class="simplebar-content" ref="contentElement">
               <slot></slot>


### PR DESCRIPTION
The previous problem was related to that if we will not pass any handler, Vue will try to use `undefined` as a function. It causes error messages in the browser's console.