### PR TITLE
feat: add support for vue 3

### DIFF
--- a/packages/simplebar-vue/index.vue
+++ b/packages/simplebar-vue/index.vue
@@ -10,8 +10,8 @@
             class="simplebar-content-wrapper"
             ref="scrollElement"
             v-on="{
-              ...($listeners.scroll && {
-                scroll: $listeners.scroll,
+              ...($attrs.onScroll && {
+                scroll: $attrs.onScroll,
               })
             }"
           >

--- a/packages/simplebar-vue/package.json
+++ b/packages/simplebar-vue/package.json
@@ -28,17 +28,16 @@
     "simplebar": "^5.3.4"
   },
   "peerDependencies": {
-    "vue": "^2.5.17"
+    "vue": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
-    "@vue/test-utils": "^1.0.0-beta.29",
-    "babel-jest": "^23.0.1",
+    "@vue/test-utils": "^2.0.0-0",
+    "babel-jest": "^24.0.1",
     "jest-serializer-vue": "^2.0.2",
-    "rollup-plugin-vue": "4.3.2",
-    "vue": "^2.5.22",
-    "vue-jest": "^3.0.4",
-    "vue-template-compiler": "^2.5.22"
+    "rollup-plugin-vue": "^6.0.0",
+    "vue": "^3.0.0",
+    "vue-jest": "^5.0.0-alpha.0"
   },
   "lint-staged": {
     "*.{js,jsx,json}": [


### PR DESCRIPTION
The existing code is essentially compatible with Vue 3. I've just updated the dependencies.

The dependency on `vue-template-compiler` has been removed, as it targets Vue 2. The upgrade route is to use `@vue/compiler-sfc`, however, as far as I can tell, this is a `rollup-vue-plugin` dep, and it builds just fine without it explicitly listed.

`$listeners` was removed in Vue 3. `$listeners.event` is now `$attrs.onEvent`, so that's been renamed.

Closes #557. If you need this patch _now_, [this](https://www.npmjs.com/package/patch-package) might be [useful](https://patch-diff.githubusercontent.com/raw/Grsmto/simplebar/pull/578.patch)