### PR TITLE
fix: Check that added/removed nodes are still present/absent

### DIFF
--- a/packages/simplebar/src/index.js
+++ b/packages/simplebar/src/index.js
@@ -54,6 +54,7 @@ SimpleBar.handleMutations = mutations => {
       if (addedNode.nodeType === 1) {
         if (addedNode.hasAttribute('data-simplebar')) {
           !SimpleBar.instances.has(addedNode) &&
+            document.documentElement.contains(addedNode) &&
             new SimpleBar(addedNode, getOptions(addedNode.attributes));
         } else {
           Array.prototype.forEach.call(
@@ -61,7 +62,8 @@ SimpleBar.handleMutations = mutations => {
             function(el) {
               if (
                 el.getAttribute('data-simplebar') !== 'init' &&
-                !SimpleBar.instances.has(el)
+                !SimpleBar.instances.has(el) &&
+                document.documentElement.contains(el)
               )
                 new SimpleBar(el, getOptions(el.attributes));
             }
@@ -74,12 +76,14 @@ SimpleBar.handleMutations = mutations => {
       if (removedNode.nodeType === 1) {
         if (removedNode.hasAttribute('[data-simplebar="init"]')) {
           SimpleBar.instances.has(removedNode) &&
+            !document.documentElement.contains(removedNode) &&
             SimpleBar.instances.get(removedNode).unMount();
         } else {
           Array.prototype.forEach.call(
             removedNode.querySelectorAll('[data-simplebar="init"]'),
             el => {
               SimpleBar.instances.has(el) &&
+                !document.documentElement.contains(el) &&
                 SimpleBar.instances.get(el).unMount();
             }
           );

--- a/packages/simplebar/src/index.js
+++ b/packages/simplebar/src/index.js
@@ -74,7 +74,7 @@ SimpleBar.handleMutations = mutations => {
 
     Array.prototype.forEach.call(mutation.removedNodes, removedNode => {
       if (removedNode.nodeType === 1) {
-        if (removedNode.hasAttribute('[data-simplebar="init"]')) {
+        if (removedNode.getAttribute('data-simplebar') === 'init') {
           SimpleBar.instances.has(removedNode) &&
             !document.documentElement.contains(removedNode) &&
             SimpleBar.instances.get(removedNode).unMount();


### PR DESCRIPTION
An element that’s moved to a different position in the DOM (such as by the constructor of a containing SimpleBar) can show up as both removed and added in a mutation record, so we need to test whether the element is currently present.

Fixes #552.