### PR TITLE
Added ability to scroll with keyboard

### DIFF
--- a/packages/simplebar-react/tests/__snapshots__/index.test.js.snap
+++ b/packages/simplebar-react/tests/__snapshots__/index.test.js.snap
@@ -22,8 +22,11 @@ exports[`renders with options 1`] = `
         style="right: -0px; bottom: 0px;"
       >
         <div
+          aria-label="scrollable content"
           class="simplebar-content-wrapper"
+          role="region"
           style="height: auto; overflow-x: hidden; overflow-y: scroll;"
+          tabindex="0"
         >
           <div
             class="simplebar-content"
@@ -95,8 +98,11 @@ exports[`renders without crashing 1`] = `
         style="right: 0px; bottom: 0px;"
       >
         <div
+          aria-label="scrollable content"
           class="simplebar-content-wrapper"
+          role="region"
           style="height: auto; overflow-x: hidden; overflow-y: hidden;"
+          tabindex="0"
         >
           <div
             class="simplebar-content"

--- a/packages/simplebar-vue/tests/__snapshots__/index.test.js.snap
+++ b/packages/simplebar-vue/tests/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`simplebar renders with default slot 1`] = `
     </div>
     <div class="simplebar-mask">
       <div class="simplebar-offset" style="right: 0px; bottom: 0px;">
-        <div class="simplebar-content-wrapper" style="height: auto; overflow-x: hidden; overflow-y: hidden;">
+        <div class="simplebar-content-wrapper" tabindex="0" role="region" aria-label="scrollable content" style="height: auto; overflow-x: hidden; overflow-y: hidden;">
           <div class="simplebar-content">
             <div class="inner-content"></div>
           </div>
@@ -34,7 +34,7 @@ exports[`simplebar renders with options 1`] = `
     </div>
     <div class="simplebar-mask">
       <div class="simplebar-offset" style="right: 0px; bottom: 0px;">
-        <div class="simplebar-content-wrapper" style="height: auto; overflow-x: hidden; overflow-y: hidden;">
+        <div class="simplebar-content-wrapper" tabindex="0" role="region" aria-label="scrollable content" style="height: auto; overflow-x: hidden; overflow-y: hidden;">
           <div class="simplebar-content"></div>
         </div>
       </div>
@@ -58,7 +58,7 @@ exports[`simplebar renders without crashing 1`] = `
     </div>
     <div class="simplebar-mask">
       <div class="simplebar-offset" style="right: 0px; bottom: 0px;">
-        <div class="simplebar-content-wrapper" style="height: auto; overflow-x: hidden; overflow-y: hidden;">
+        <div class="simplebar-content-wrapper" tabindex="0" role="region" aria-label="scrollable content" style="height: auto; overflow-x: hidden; overflow-y: hidden;">
           <div class="simplebar-content"></div>
         </div>
       </div>

--- a/packages/simplebar/README.md
+++ b/packages/simplebar/README.md
@@ -199,6 +199,14 @@ forceVisible: true|'x'|'y' (default to `false`)
 
 By default, SimpleBar behave like `overflow: auto`.
 
+### ariaLabel
+
+You can set custom aria-label attribute for users with screen reader using the `ariaLabel` option:
+
+```
+ariaLabel: 'Your label' (default to `scrollable content`)
+```
+
 #### direction (RTL support)
 
 You can activate RTL support by passing the `direction` option:

--- a/packages/simplebar/src/simplebar.js
+++ b/packages/simplebar/src/simplebar.js
@@ -157,6 +157,8 @@ export default class SimpleBar {
     if (canUseDOM) {
       this.initDOM();
 
+      this.setAccessibilityAttributes();
+
       this.scrollbarWidth = this.getScrollbarWidth();
 
       this.recalculate();
@@ -272,6 +274,14 @@ export default class SimpleBar {
     }
 
     this.el.setAttribute('data-simplebar', 'init');
+  }
+
+  setAccessibilityAttributes() {
+    const ariaLabel = this.options.ariaLabel || 'scrollable content';
+
+    this.contentWrapperEl.setAttribute('tabindex', '0');
+    this.contentWrapperEl.setAttribute('role', 'region');
+    this.contentWrapperEl.setAttribute('aria-label', ariaLabel);
   }
 
   initListeners() {


### PR DESCRIPTION
It was impossible to scroll slider with keyboard in Chrome and Safari.
I added `tabindex="0"` to allow focusing on slider and `aria-label` for screen readers.
More info here https://marcus.io/blog/accessible-overflow