### PR TITLE
Allow angular v8.1.3 – v13 as peer dependency

### DIFF
--- a/packages/simplebar-angular/package.json
+++ b/packages/simplebar-angular/package.json
@@ -30,8 +30,8 @@
     "simplebar": "^5.3.6"
   },
   "peerDependencies": {
-    "@angular/common": "^8.1.3",
-    "@angular/core": "^8.1.3"
+    "@angular/common": "^8.1.3 || ^9 || ^10 || ^11 || ^12 || ^13",
+    "@angular/core": "^8.1.3 || ^9 || ^10 || ^11 || ^12 || ^13"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.801.3",


### PR DESCRIPTION
Any chance we can allow newer angular versions as peer dependency? Or any hint on how we can properly get around warnings like `Package "simplebar-angular" has an incompitible peer dependency to "@angular/common" (requires "^8.1.3" (extended), would install "13.0.2"`?