### PR TITLE
fix: ensure native scrollbars are hidden on recent iOS versions

### DIFF
--- a/packages/simplebar/src/simplebar.css
+++ b/packages/simplebar/src/simplebar.css
@@ -59,6 +59,7 @@
 
 .simplebar-content-wrapper::-webkit-scrollbar,
 .simplebar-hide-scrollbar::-webkit-scrollbar {
+  display: none;
   width: 0;
   height: 0;
 }


### PR DESCRIPTION
fix #568 #521 #445