### PR TITLE
[simplebar-vue] fix: move vue-demi to dependencies

### DIFF
--- a/packages/simplebar-vue/package.json
+++ b/packages/simplebar-vue/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "core-js": "^3.0.1",
-    "simplebar": "^5.3.9"
+    "simplebar": "^5.3.9",
+    "vue-demi": "^0.13.11"
   },
   "peerDependencies": {
     "vue": "^3.0.0-0 || ^2.6.14"
@@ -49,7 +50,6 @@
     "jest-serializer-vue": "^2.0.2",
     "rollup-plugin-vue": "^6.0.0",
     "vue": "^3.2.45",
-    "vue-demi": "0.13.5",
     "vue-jest": "^5.0.0-alpha.0",
     "vue-jest2": "npm:vue-jest@4",
     "vue-template-compiler2.6": "npm:vue-template-compiler@2.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22889,10 +22889,10 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-vue-demi@0.13.5:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.5.tgz#d5eddbc9eaefb89ce5995269d1fa6b0486312092"
-  integrity sha512-tO3K2bML3AwiHmVHeKCq6HLef2st4zBXIV5aEkoJl6HZ+gJWxWv2O8wLH8qrA3SX3lDoTDHNghLX1xZg83MXvw==
+vue-demi@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.11.tgz#7d90369bdae8974d87b1973564ad390182410d99"
+  integrity sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==
 
 vue-eslint-parser@^8.0.1:
   version "8.3.0"


### PR DESCRIPTION
First I would like to apologise for breaking the `1.7.0` build :/  
I've trusted unit testing and [forgot to install it externally ](https://codesandbox.io/s/simplebar-1-7-0-0u4s8x) to ensure it works _in real life_, or should have asked you to release it as beta.

https://github.com/Grsmto/simplebar/blob/3c5cb8d4f9848f80e64b0196c438bb5b2243c68f/packages/simplebar-vue/utils.js#L1-L6

1. `vue-demi` is not only used for testing but also to dynamically create the lifecyle names map for cross-compatiblity with vue 2 and 3
1. updated `vue-demi` to latest version, I was going crazy to make the tests work and thought that vue-demi had something to do with it but I has not.