### PR TITLE
Fix typo in README (simplebar/src/simplebar)

### DIFF
--- a/packages/simplebar/README.md
+++ b/packages/simplebar/README.md
@@ -127,7 +127,7 @@ or
 ```js
 Array.prototype.forEach.call(
   document.querySelectorAll('.myElements'),
-  (el) => new SimpleBar()
+  (el) => new SimpleBar(el)
 );
 ```
 


### PR DESCRIPTION
Found a small typo in README