### PR TITLE
chore: support vue 3

### DIFF
--- a/packages/simplebar-vue/package.json
+++ b/packages/simplebar-vue/package.json
@@ -38,7 +38,7 @@
     "vue-demi": "^0.13.11"
   },
   "peerDependencies": {
-    "vue": "^2.5.17"
+    "vue": "^2.5.17 || ^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",


### PR DESCRIPTION
Any reason to have Vue 2 as peer depedency, when it works fine with Vue 3 that was out like 3 years ago? I think changing just that peer should be enough to officially support vue 3.