### PR TITLE
Add types field to package.json

### DIFF
--- a/packages/simplebar-core/package.json
+++ b/packages/simplebar-core/package.json
@@ -34,12 +34,12 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
+    "@types/lodash-es": "^4.17.6",
     "can-use-dom": "^0.1.0",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {
-    "@types/lodash-es": "^4.17.6",
     "browserstack-local": "^1.5.1"
   },
   "lint-staged": {

--- a/packages/simplebar/package.json
+++ b/packages/simplebar/package.json
@@ -16,6 +16,7 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "unpkg": "./dist/simplebar.min.js",
   "style": "./dist/simplebar.min.css",
   "homepage": "https://grsmto.github.io/simplebar/",


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

Fixes this error:

```console
$ npm i simplebar
$ tsc --init
$ echo 'import SimpleBar from "simplebar"' > test.ts
$ tsc
test.ts:1:23 - error TS7016: Could not find a declaration file for module 'simplebar'. '/tmp/test/node_modules/simplebar/dist/index.cjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/simplebar` if it exists or add a new declaration (.d.ts) file containing `declare module 'simplebar';`

1 import SimpleBar from "simplebar"
                        ~~~~~~~~~~~


Found 1 error in test.ts:1
```