### PR TITLE
fix(core): Fix vertical scrollbar dragging in rtl mode

### DIFF
--- a/packages/simplebar-core/src/index.ts
+++ b/packages/simplebar-core/src/index.ts
@@ -874,7 +874,7 @@ export default class SimpleBarCore {
       eventOffset -
       (track.rect?.[this.axis[this.draggedAxis].offsetAttr] ?? 0) -
       this.axis[this.draggedAxis].dragOffset;
-    dragPos = this.isRtl
+    dragPos = this.draggedAxis === 'x' && this.isRtl
       ? (track.rect?.[this.axis[this.draggedAxis].sizeAttr] ?? 0) -
         scrollbar.size -
         dragPos


### PR DESCRIPTION
Should fix #659 issue.

### Issue:

When dragging vertical scrollbar handle, it moves in reverse position when wrapper is in RTL mode. It looks like handle movement is reversed in RTL mode both, for horizontal (which is how it should be) and for vertical scrollbar (which is undesired behavior, as RTL layout doesn't change vertical page layout). You can also see the example in comments for issue, mentioned above.

### What is done to fix it:

Add additional checks for dragging position: scroll handle movement is inverted when layout is RTL (older check) and only when moving X axis (new check)