### PR TITLE
fix(vue&react): fix some demo codes  in examples and README

### DIFF
--- a/examples/react/src/App.js
+++ b/examples/react/src/App.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import SimpleBar from 'simplebar-react';
 
-import 'simplebar/dist/simplebar.min.css';
+import 'simplebar-react/dist/simplebar.min.css';
 import logo from './logo.svg';
 import './App.css';
 

--- a/examples/vue-2.7/src/App.vue
+++ b/examples/vue-2.7/src/App.vue
@@ -6,7 +6,7 @@
 
 <script>
 import simplebar from 'simplebar-vue';
-import 'simplebar/dist/simplebar.min.css';
+import 'simplebar-vue/dist/simplebar.min.css';
 
 export default {
   name: 'app',

--- a/examples/vue-3/src/App.vue
+++ b/examples/vue-3/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import Simplebar from 'simplebar-vue';
-// import 'simplebar-vue/dist/simplebar.min.css';
+import 'simplebar-vue/dist/simplebar.min.css';
 </script>
 
 <template>

--- a/packages/simplebar-vue/README.md
+++ b/packages/simplebar-vue/README.md
@@ -26,13 +26,13 @@
 
 ### Usage
 
-Check out the [Demo project](https://github.com/Grsmto/simplebar/blob/master/examples/vue).
+Check out the [Demo project(vue2)](https://github.com/Grsmto/simplebar/blob/master/examples/vue-2.7/src/App.vue) and the [Demo project(vue3)](https://github.com/Grsmto/simplebar/blob/master/examples/vue-3/src/App.vue)
 
 First, register it in your Vue app:
 
 ```js
 import simplebar from 'simplebar-vue';
-import 'simplebar/dist/simplebar.min.css';
+import 'simplebar-vue/dist/simplebar.min.css';
 
 export default {
   components: {


### PR DESCRIPTION
demo code in packages/simplebar-vue not working because the styles are not correctly imported. Also, the link to vue-demo is not correct. Fixed these and some similar problems in examples.