### PR TITLE
Fix typo in README (react)

### DIFF
--- a/packages/simplebar-react/README.md
+++ b/packages/simplebar-react/README.md
@@ -118,11 +118,11 @@ If you define your own elements you should do:
 
 ```js
 <SimpleBar>
-  {({ scrollableNodeProps, scrollableNodeProps }) => {
+  {({ scrollableNodeProps, contentNodeProps }) => {
     return (
       <div {...scrollableNodeProps}>
         outer/scrollable element
-        <div {...scrollableNodeProps} />inner element</div>
+        <div {...contentNodeProps} />inner element</div>
       </div>
     );
   }}


### PR DESCRIPTION
### Issue:
I think there is a typo error in README (simplebar-react package). In Simplebar component's render prop pattern, props showed two objects with the same name.

### What is done to fix it:
When we use render prop pattern, the props are scrollableNodeProps, contentNodeProps.