### PR TITLE
Reduce runtime dependencies

### DIFF
--- a/packages/simplebar-core/can-use-dom.d.ts
+++ b/packages/simplebar-core/can-use-dom.d.ts
@@ -1,1 +1,0 @@
-declare module 'can-use-dom';

--- a/packages/simplebar-core/package.json
+++ b/packages/simplebar-core/package.json
@@ -34,12 +34,10 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "@types/lodash-es": "^4.17.6",
-    "can-use-dom": "^0.1.0",
-    "lodash": "^4.17.21",
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {
+    "@types/lodash-es": "^4.17.6",
     "browserstack-local": "^1.5.1"
   },
   "lint-staged": {

--- a/packages/simplebar-core/rollup.config.mjs
+++ b/packages/simplebar-core/rollup.config.mjs
@@ -31,7 +31,6 @@ export default [
         format: 'umd',
         sourcemap: true,
         globals: {
-          'can-use-dom': 'canUseDOM',
           'lodash-es': '_',
         },
         paths: {

--- a/packages/simplebar-core/src/helpers.ts
+++ b/packages/simplebar-core/src/helpers.ts
@@ -1,5 +1,9 @@
 import type { SimpleBarOptions } from './index';
 
+export function canUseDOM() {
+  return !!(typeof window !== 'undefined' && window.document && window.document.createElement);
+}
+
 export function getElementWindow(element: Element) {
   if (
     !element ||

--- a/packages/simplebar-core/src/index.ts
+++ b/packages/simplebar-core/src/index.ts
@@ -1,6 +1,5 @@
 import type { DebouncedFunc } from 'lodash-es';
 import { debounce, throttle } from 'lodash-es';
-import canUseDOM from 'can-use-dom';
 import scrollbarWidth from './scrollbar-width';
 import * as helpers from './helpers';
 
@@ -291,7 +290,7 @@ export default class SimpleBarCore {
 
   init() {
     // We stop here on server-side
-    if (canUseDOM) {
+    if (helpers.canUseDOM()) {
       this.initDOM();
 
       this.rtlHelpers = SimpleBarCore.getRtlHelpers();

--- a/packages/simplebar-core/src/scrollbar-width.ts
+++ b/packages/simplebar-core/src/scrollbar-width.ts
@@ -1,9 +1,9 @@
-import canUseDOM from 'can-use-dom';
+import { canUseDOM } from "./helpers";
 
 let cachedScrollbarWidth: number | null = null;
 let cachedDevicePixelRatio: number | null = null;
 
-if (canUseDOM) {
+if (canUseDOM()) {
   window.addEventListener('resize', () => {
     if (cachedDevicePixelRatio !== window.devicePixelRatio) {
       cachedDevicePixelRatio = window.devicePixelRatio;

--- a/packages/simplebar/can-use-dom.d.ts
+++ b/packages/simplebar/can-use-dom.d.ts
@@ -1,1 +1,0 @@
-declare module 'can-use-dom';

--- a/packages/simplebar/package.json
+++ b/packages/simplebar/package.json
@@ -30,7 +30,6 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "can-use-dom": "^0.1.0",
     "simplebar-core": "^1.2.5"
   },
   "devDependencies": {

--- a/packages/simplebar/rollup.config.mjs
+++ b/packages/simplebar/rollup.config.mjs
@@ -37,7 +37,6 @@ if (process.env.BUILD !== 'development') {
       format: 'umd',
       exports: 'named',
       globals: {
-        'can-use-dom': 'canUseDOM',
         'simplebar-core': 'SimpleBar',
       },
     },
@@ -54,9 +53,6 @@ if (process.env.BUILD !== 'development') {
       name: 'SimpleBar',
       file: pkg.unpkg,
       format: 'iife',
-      globals: {
-        'can-use-dom': 'canUseDOM',
-      },
     },
     plugins: [
       resolve(),
@@ -75,9 +71,6 @@ if (process.env.BUILD !== 'development') {
         name: 'SimpleBar',
         file: 'dist/simplebar.js',
         format: 'iife',
-        globals: {
-          'can-use-dom': 'canUseDOM',
-        },
       },
       plugins: [
         resolve(),

--- a/packages/simplebar/src/index.ts
+++ b/packages/simplebar/src/index.ts
@@ -1,7 +1,6 @@
-import canUseDOM from 'can-use-dom';
 import SimpleBarCore from 'simplebar-core';
 
-const { getOptions, addClasses } = SimpleBarCore.helpers;
+const { getOptions, addClasses, canUseDOM } = SimpleBarCore.helpers;
 
 export default class SimpleBar extends SimpleBarCore {
   static globalObserver: MutationObserver;
@@ -195,6 +194,6 @@ export default class SimpleBar extends SimpleBarCore {
  * HTML API
  * Called only in a browser env.
  */
-if (canUseDOM) {
+if (canUseDOM()) {
   SimpleBar.initHtmlApi();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4093,7 +4093,7 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@prettier/eslint@npm:prettier-eslint@^15.0.1", prettier-eslint@^15.0.1:
+"@prettier/eslint@npm:prettier-eslint@^15.0.1":
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-15.0.1.tgz#2543a43e9acec2a9767ad6458165ce81f353db9c"
   integrity sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==
@@ -7416,11 +7416,6 @@ camelcase@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-7.0.1.tgz#f02e50af9fd7782bc8b88a3558c32fd3a388f048"
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
-
-can-use-dom@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
-  integrity sha512-ceOhN1DL7Y4O6M0j9ICgmTYziV89WMd96SvSl0REd8PMgrY0B/WBOPoed5S1KUmJqXgUXh8gzSe6E3ae27upsQ==
 
 caniuse-api@^1.5.2:
   version "1.6.1"
@@ -19060,6 +19055,26 @@ prettier-eslint-cli@^7.1.0:
     loglevel-colored-level-prefix "^1.0.0"
     rxjs "^7.5.6"
     yargs "^13.1.1"
+
+prettier-eslint@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-15.0.1.tgz#2543a43e9acec2a9767ad6458165ce81f353db9c"
+  integrity sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==
+  dependencies:
+    "@types/eslint" "^8.4.2"
+    "@types/prettier" "^2.6.0"
+    "@typescript-eslint/parser" "^5.10.0"
+    common-tags "^1.4.0"
+    dlv "^1.1.0"
+    eslint "^8.7.0"
+    indent-string "^4.0.0"
+    lodash.merge "^4.6.0"
+    loglevel-colored-level-prefix "^1.0.0"
+    prettier "^2.5.1"
+    pretty-format "^23.0.1"
+    require-relative "^0.8.7"
+    typescript "^4.5.4"
+    vue-eslint-parser "^8.0.1"
 
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Runtime dependency count is decently low already, but a few more can be cut out with minimal changes.