### PR TITLE
Clean up unused dependencies

### DIFF
--- a/packages/simplebar-core/can-use-dom.d.ts
+++ b/packages/simplebar-core/can-use-dom.d.ts
@@ -1,1 +1,0 @@
-declare module 'can-use-dom';

--- a/packages/simplebar-core/package.json
+++ b/packages/simplebar-core/package.json
@@ -34,11 +34,10 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "@types/lodash-es": "^4.17.6",
-    "lodash": "^4.17.21",
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {
+    "@types/lodash-es": "^4.17.6",
     "browserstack-local": "^1.5.1"
   },
   "lint-staged": {

--- a/packages/simplebar/can-use-dom.d.ts
+++ b/packages/simplebar/can-use-dom.d.ts
@@ -1,1 +1,0 @@
-declare module 'can-use-dom';

--- a/packages/simplebar/package.json
+++ b/packages/simplebar/package.json
@@ -30,7 +30,6 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "can-use-dom": "^0.1.0",
     "simplebar-core": "^1.2.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8901,11 +8901,6 @@ camelcase@^7.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-7.0.1.tgz#f02e50af9fd7782bc8b88a3558c32fd3a388f048"
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
-can-use-dom@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
-  integrity sha512-ceOhN1DL7Y4O6M0j9ICgmTYziV89WMd96SvSl0REd8PMgrY0B/WBOPoed5S1KUmJqXgUXh8gzSe6E3ae27upsQ==
-
 caniuse-api@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"


### PR DESCRIPTION
There are still some dependencies to clean up
- Removed unused `can-use-dom` dependency from simplebar
- Removed unused `lodash` dependency from simplebar-core
- Moved `@types/lodash-es` in simplebar-core to a dev dependency