### PR TITLE
fix(Angular): fixed applying custom tabIndex and ariaLabel

### DIFF
--- a/packages/simplebar-angular/src/lib/simplebar-angular.component.ts
+++ b/packages/simplebar-angular/src/lib/simplebar-angular.component.ts
@@ -25,18 +25,19 @@ export class SimplebarAngularComponent implements OnInit, AfterViewInit {
 
   elRef: ElementRef;
   SimpleBar: any;
-  ariaLabel: string;
-  tabIndex: string;
+  ariaLabel!: string;
+  tabIndex!: string;
 
   constructor(elRef: ElementRef, private zone: NgZone) {
     this.elRef = elRef;
+  }
+
+  ngOnInit(): void {
     this.ariaLabel =
       this.options.ariaLabel || SimpleBar.defaultOptions.ariaLabel;
     this.tabIndex =
       (this.options.tabIndex || SimpleBar.defaultOptions.tabIndex).toString();
   }
-
-  ngOnInit() {}
 
   ngAfterViewInit(): void {
     this.zone.runOutsideAngular(() => {
@@ -47,7 +48,7 @@ export class SimplebarAngularComponent implements OnInit, AfterViewInit {
     });
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.SimpleBar?.unMount();
     this.SimpleBar = null;
   }


### PR DESCRIPTION
It seems that setting `tabIndex` and `ariaLabel `doesn't work as expected in Angular. `tabIndex `and `ariaLabel `always have their default values. To resolve this, the assignment of `ariaLabel` and `tabIndex` should be moved inside the `ngOnInit` method, as the constructor is called before the component is fully initialized.
At that point, `this.options` is still an empty object, rather than the options passed from the outside via the `@Input` parameter.