### PR TITLE
Add types to exports

### DIFF
--- a/packages/simplebar/package.json
+++ b/packages/simplebar/package.json
@@ -22,7 +22,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     },
     "./dist/simplebar.min.css": "./dist/simplebar.min.css"
   },


### PR DESCRIPTION
Solves an issue when importing `SimpleBar` in a project using esm and tyepscript:

```
Could not find a declaration file for module 'simplebar'.
```

This is because the index.d.ts file cannot be used because it is not in the package exports.