### PR TITLE
Add types to exports field

### DIFF
--- a/packages/simplebar/package.json
+++ b/packages/simplebar/package.json
@@ -22,7 +22,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     },
     "./dist/simplebar.min.css": "./dist/simplebar.min.css"
   },


### PR DESCRIPTION
Without the `types` field in the `exports`, TypeScript cannot find the types:

```
Could not find a declaration file for module 'simplebar'. '/home/user/.yarn/berry/cache/simplebar-npm-6.3.1-d58b3da355-10.zip/node_modules/simplebar/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/home/user/.yarn/berry/cache/simplebar-npm-6.3.1-d58b3da355-10.zip/node_modules/simplebar/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'simplebar' library may need to update its package.json or typings.ts(7016)
```

See #719